### PR TITLE
Add ability to override `query/3` function in filters

### DIFF
--- a/lib/backpex/filters/boolean.ex
+++ b/lib/backpex/filters/boolean.ex
@@ -127,6 +127,8 @@ defmodule Backpex.Filters.Boolean do
         Enum.map(options(), fn %{predicate: p, key: k} -> {k, p} end)
         |> Enum.into(%{})
       end
+
+      defoverridable query: 3
     end
   end
 end

--- a/lib/backpex/filters/multi_select.ex
+++ b/lib/backpex/filters/multi_select.ex
@@ -126,6 +126,8 @@ defmodule Backpex.Filters.MultiSelect do
         </div>
         """
       end
+
+      defoverridable query: 3
     end
   end
 end

--- a/lib/backpex/filters/range.ex
+++ b/lib/backpex/filters/range.ex
@@ -163,6 +163,8 @@ defmodule Backpex.Filters.Range do
         </div>
         """
       end
+
+      defoverridable query: 3
     end
   end
 end

--- a/lib/backpex/filters/select.ex
+++ b/lib/backpex/filters/select.ex
@@ -80,6 +80,8 @@ defmodule Backpex.Filters.Select do
 
       defp selected(""), do: nil
       defp selected(value), do: value
+
+      defoverridable query: 3
     end
   end
 end


### PR DESCRIPTION
We do not have the ability to override the `query/3` function for filters. So I added a `defoverridable` call to each filter. This gives more flexibility to the filters.