### PR TITLE
Fix whitespaces when no live resource is specified

### DIFF
--- a/lib/backpex/fields/has_many.ex
+++ b/lib/backpex/fields/has_many.ex
@@ -339,9 +339,9 @@ defmodule Backpex.Fields.HasMany do
 
     ~H"""
     <%= if is_nil(@link) do %>
-      <p class={@live_action in [:index, :resource_action] && "truncate"}>
+      <span class={@live_action in [:index, :resource_action] && "truncate"}>
         <%= HTML.pretty_value(@display_text) %>
-      </p>
+      </span>
     <% else %>
       <.link navigate={@link} class={["hover:underline", @live_action in [:index, :resource_action] && "truncate"]}>
         <%= @display_text %>

--- a/lib/backpex/fields/many_to_many.ex
+++ b/lib/backpex/fields/many_to_many.ex
@@ -339,9 +339,9 @@ defmodule Backpex.Fields.ManyToMany do
 
     ~H"""
     <%= if is_nil(@link) do %>
-      <p class={@live_action in [:index, :resource_action] && "truncate"}>
+      <span class={@live_action in [:index, :resource_action] && "truncate"}>
         <%= HTML.pretty_value(@display_text) %>
-      </p>
+      </span>
     <% else %>
       <.link navigate={@link} class={["hover:underline", @live_action in [:index, :resource_action] && "truncate"]}>
         <%= @display_text %>


### PR DESCRIPTION
In the `HasMany` and `ManyToMany` fields, if no LiveResource was configured, there were blocks of whitespace between elements in show view.

**Before**
<img width="1223" alt="image" src="https://github.com/naymspace/backpex/assets/60519307/91d6baa6-0348-4276-ae5b-6a9790a93b5f">

**After**
<img width="1224" alt="image" src="https://github.com/naymspace/backpex/assets/60519307/4541ea2e-a962-46ee-94dd-427451924b48">

