### PR TITLE
Adjust multi select filter width

### DIFF
--- a/demo/lib/demo_web/live/home_live/index.html.heex
+++ b/demo/lib/demo_web/live/home_live/index.html.heex
@@ -29,7 +29,9 @@
         <.link navigate="/admin/users" class="mr-6">
           <button class="btn btn-primary">View Demo</button>
         </.link>
-        <.link href="https://hexdocs.pm/backpex" class="text-sm font-semibold leading-6 text-gray-900 hover:underline">Documentation</.link>
+        <.link href="https://hexdocs.pm/backpex" class="text-sm font-semibold leading-6 text-gray-900 hover:underline">
+          Documentation
+        </.link>
         <Heroicons.arrow_right class="ml-2 h-4 w-4" />
       </div>
       <div :if={not @form_hidden?} class="bg-white py-8 sm:py-12 lg:py-16">

--- a/lib/backpex/filters/multi_select.ex
+++ b/lib/backpex/filters/multi_select.ex
@@ -98,7 +98,7 @@ defmodule Backpex.Filters.MultiSelect do
           </div>
           <ul
             tabindex="0"
-            class="dropdown-content z-[1] menu bg-base-100 rounded-box max-h-96 w-60 overflow-y-auto p-2 shadow"
+            class="dropdown-content z-[1] menu bg-base-100 rounded-box max-h-96 min-w-60 w-max overflow-y-auto p-2 shadow"
             x-show="open"
             @click.outside="open = false"
           >

--- a/lib/backpex/filters/multi_select.ex
+++ b/lib/backpex/filters/multi_select.ex
@@ -98,7 +98,7 @@ defmodule Backpex.Filters.MultiSelect do
           </div>
           <ul
             tabindex="0"
-            class="dropdown-content z-[1] menu bg-base-100 rounded-box max-h-96 min-w-60 w-max overflow-y-auto p-2 shadow"
+            class="dropdown-content z-[1] menu bg-base-100 rounded-box min-w-60 max-h-96 w-max overflow-y-auto p-2 shadow"
             x-show="open"
             @click.outside="open = false"
           >


### PR DESCRIPTION
To conform to the native HTML select (and backpex select filter), I changed the multi select filter width to `w-max`. This prevents long texts from wrapping.

![Bildschirmfoto 2024-01-05 um 10 28 07](https://github.com/naymspace/backpex/assets/60519307/e87dc402-e110-409c-89e7-fed429b6ff0d)