### PR TITLE
Pass assigns to changeset function

### DIFF
--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -80,7 +80,7 @@ defmodule Backpex.FormComponent do
 
     changeset =
       Ecto.Changeset.change(assigns.item_action_types)
-      |> validate_change(changeset_function, change, target)
+      |> validate_change(changeset_function, change, assigns, target)
 
     socket = assign(socket, changeset: changeset)
 
@@ -96,7 +96,7 @@ defmodule Backpex.FormComponent do
     changeset =
       Ecto.Changeset.change(item)
       |> put_assocs(assocs)
-      |> validate_change(changeset_function, change, target)
+      |> validate_change(changeset_function, change, assigns, target)
 
     send(self(), {:update_changeset, changeset})
 
@@ -144,7 +144,7 @@ defmodule Backpex.FormComponent do
 
     changeset =
       Ecto.Changeset.change(assigns.item_action_types)
-      |> validate_change(changeset_function, change, nil)
+      |> validate_change(changeset_function, change, assigns, nil)
 
     socket = assign(socket, changeset: changeset)
 
@@ -162,7 +162,7 @@ defmodule Backpex.FormComponent do
     changeset =
       Ecto.Changeset.change(item)
       |> put_assocs(assocs)
-      |> validate_change(changeset_function, change, nil)
+      |> validate_change(changeset_function, change, assigns, nil)
 
     socket = assign(socket, changeset: changeset)
 
@@ -193,9 +193,9 @@ defmodule Backpex.FormComponent do
     {:noreply, socket}
   end
 
-  defp validate_change(item, changeset_function, change, target) do
+  defp validate_change(item, changeset_function, change, assigns, target) do
     item
-    |> LiveResource.call_changeset_function(changeset_function, change, target)
+    |> LiveResource.call_changeset_function(changeset_function, change, assigns, target)
     |> Map.put(:action, :validate)
   end
 

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -197,7 +197,7 @@ defmodule Backpex.LiveResource do
       def can?(_assigns, :my_item_action, item), do: item.role == :admin
 
       def can?(assigns, :my_resource_action, nil), do: assigns.current_user == :admin
-      
+
   > Note that item actions are always displayed if they are defined. If you want to remove item actions completely, you must restrict access to them with `can?/3` and remove the action with the `item_actions/1` function.
 
   ## Resource Actions
@@ -659,8 +659,8 @@ defmodule Backpex.LiveResource do
     * `:layout` - Layout to be used by the LiveResource.
     * `:schema` - Schema for the resource.
     * `:repo` - Ecto repo that will be used to perform CRUD operations for the given schema.
-    * `:update_changeset` - Changeset that will be used when updating items. Optionally takes the target as the third parameter.
-    * `:create_changeset` - Changeset that will be used when creating items. Optionally takes the target as the third parameter.
+    * `:update_changeset` - Changeset to use when updating items. Optionally takes the target as the third parameter and the assigns as the fourth.
+    * `:create_changeset` - Changeset to use when creating items. Optionally takes the target as the third parameter and the assigns as the fourth.
     * `:pubsub` - PubSub name of the project.
     * `:topic` - The topic for PubSub.
     * `:event_prefix` - The event prefix for Pubsub, to differentiate between events of different resources when subscribed to multiple resources.
@@ -1008,7 +1008,8 @@ defmodule Backpex.LiveResource do
           Backpex.LiveResource.call_changeset_function(
             item,
             changeset_function,
-            default_attrs(live_action, fields, assigns)
+            default_attrs(live_action, fields, assigns),
+            assigns
           )
 
         socket
@@ -1967,13 +1968,13 @@ defmodule Backpex.LiveResource do
   @doc """
   Calls the changeset function with the given change and target.
   """
-  def call_changeset_function(item, changeset_function, change, target \\ nil) do
+  def call_changeset_function(item, changeset_function, change, assigns, target \\ nil) do
     arity = :erlang.fun_info(changeset_function)[:arity]
 
-    if arity == 2 do
-      changeset_function.(item, change)
-    else
-      changeset_function.(item, change, target)
+    case arity do
+      2 -> changeset_function.(item, change)
+      3 -> changeset_function.(item, change, target)
+      4 -> changeset_function.(item, change, target, assigns)
     end
   end
 

--- a/lib/backpex/resource.ex
+++ b/lib/backpex/resource.ex
@@ -300,7 +300,7 @@ defmodule Backpex.Resource do
 
     changeset
     |> prepare_for_validation()
-    |> LiveResource.call_changeset_function(changeset_function, change)
+    |> LiveResource.call_changeset_function(changeset_function, change, assigns)
     |> repo.update()
     |> broadcast("updated", assigns)
   end
@@ -335,7 +335,7 @@ defmodule Backpex.Resource do
 
     changeset
     |> prepare_for_validation()
-    |> LiveResource.call_changeset_function(changeset_function, change)
+    |> LiveResource.call_changeset_function(changeset_function, change, assigns)
     |> repo.insert()
     |> broadcast("created", assigns)
   end


### PR DESCRIPTION
There is a case where we need to access a user in the changeset to validate permissions to change a particular field. In a Phoenix / LiveView application without Backpex, you could handle this case in the event handler before calling a changeset function. In Backpex we currently have no layer between the event and the changeset function. So we have to access the user via the assigns in the changeset function. We pass the `_target` to the changeset function for the same reason.

I suppose there is a better but more complex solution than passing all assigns to every function to handle such cases. Perhaps we should add more layers to hook into. We should address this in future updates! 