### PR TITLE
Improve breaking words

### DIFF
--- a/lib/backpex/html/layout.ex
+++ b/lib/backpex/html/layout.ex
@@ -408,7 +408,7 @@ defmodule Backpex.HTML.Layout do
   def field_container(assigns) do
     ~H"""
     <div class={"#{@class} flex flex-col items-stretch space-y-2 px-6 py-4 sm:flex-row sm:space-y-0 sm:py-3"}>
-      <div :for={label <- @label} class={"#{get_align_class(label[:align])} w-1/4"}>
+      <div :for={label <- @label} class={"#{get_align_class(label[:align])} sm:w-1/4 pr-2 break-words hyphens-auto"}>
         <%= render_slot(@label) %>
       </div>
 

--- a/lib/backpex/html/layout.ex
+++ b/lib/backpex/html/layout.ex
@@ -408,7 +408,7 @@ defmodule Backpex.HTML.Layout do
   def field_container(assigns) do
     ~H"""
     <div class={"#{@class} flex flex-col items-stretch space-y-2 px-6 py-4 sm:flex-row sm:space-y-0 sm:py-3"}>
-      <div :for={label <- @label} class={"#{get_align_class(label[:align])} sm:w-1/4 pr-2 break-words hyphens-auto"}>
+      <div :for={label <- @label} class={"#{get_align_class(label[:align])} hyphens-auto break-words pr-2 sm:w-1/4"}>
         <%= render_slot(@label) %>
       </div>
 


### PR DESCRIPTION
When using long names for field labels, the word does not break properly. Especially in the German language this is a problem. I have added a `hyphens-auto` class along with some padding to break words properly. This change requires the HTML `lang` attribute to be changed to the appropriate language.

Example:
![image](https://github.com/naymspace/backpex/assets/60519307/707fedd0-d4f1-4690-aeda-96b46ac6d55a)
