### PR TITLE
Render modal even if its not open

### DIFF
--- a/lib/backpex/html/layout.ex
+++ b/lib/backpex/html/layout.ex
@@ -440,10 +440,13 @@ defmodule Backpex.HTML.Layout do
       |> assign(:classes, get_modal_classes(assigns))
 
     ~H"""
-    <div :if={@open} id="modal">
+    <div id="modal">
       <div
         id="modal-overlay"
-        class="animate-fade-in fixed inset-0 z-50 bg-gray-900 bg-opacity-30 transition-opacity"
+        class={[
+          "animate-fade-in fixed inset-0 z-50 bg-gray-900 bg-opacity-30 transition-opacity",
+          unless(@open, do: "hidden")
+        ]}
         aria-hidden="true"
       >
       </div>
@@ -458,9 +461,9 @@ defmodule Backpex.HTML.Layout do
       >
         <div
           class={@classes}
-          phx-click-away={hide_modal(@target, @close_event_name)}
-          phx-window-keydown={hide_modal(@target, @close_event_name)}
-          phx-key="escape"
+          phx-click-away={@open && hide_modal(@target, @close_event_name)}
+          phx-window-keydown={@open && hide_modal(@target, @close_event_name)}
+          phx-key={@open && "escape"}
         >
           <!-- Header -->
           <div class="border-b border-gray-100 px-5 py-3">


### PR DESCRIPTION
We had some strange behaviour in the `HasManyThrough` field that caused the linked values to reset when other form elements changed. This was the result of a change where we prevent the entire modal markup from rendering if it is not open. The way the `HasManyThrough` field currently works is that it stores the current state in the form inputs of the modal. This means that the modal markup has to be rendered even if if the modal is not open.

To prevent the Live View from crashing when certain keys are pressed when the modal is closed, we now conditionally assign these events based on the open state of the modal.

We should address this when reworking the `HasManyThrough` field.