### PR TITLE
Fix duplicated id for index form inputs

### DIFF
--- a/lib/backpex/fields/number.ex
+++ b/lib/backpex/fields/number.ex
@@ -37,7 +37,10 @@ defmodule Backpex.Fields.Number do
 
   @impl Backpex.Field
   def render_index_form(assigns) do
-    assigns = assign_new(assigns, :valid, fn -> true end)
+    assigns =
+      assigns
+      |> assign(:input_id, "index_input_#{assigns.item.id}")
+      |> assign_new(:valid, fn -> true end)
 
     ~H"""
     <div>
@@ -56,7 +59,8 @@ defmodule Backpex.Fields.Number do
           class: ["input input-sm", if(@valid, do: "hover:input-bordered", else: "input-error")],
           value: @value,
           phx_debounce: "100",
-          readonly: @readonly
+          readonly: @readonly,
+          id: @input_id
         ) %>
       </.form>
     </div>

--- a/lib/backpex/fields/number.ex
+++ b/lib/backpex/fields/number.ex
@@ -39,7 +39,7 @@ defmodule Backpex.Fields.Number do
   def render_index_form(assigns) do
     assigns =
       assigns
-      |> assign(:input_id, "index_input_#{assigns.item.id}")
+      |> assign(:input_id, "index_input_#{assigns.item.id}_#{assigns.name}")
       |> assign_new(:valid, fn -> true end)
 
     ~H"""

--- a/lib/backpex/fields/text.ex
+++ b/lib/backpex/fields/text.ex
@@ -58,7 +58,7 @@ defmodule Backpex.Fields.Text do
   def render_index_form(assigns) do
     assigns =
       assigns
-      |> assign(:input_id, "index_input_#{assigns.item.id}")
+      |> assign(:input_id, "index_input_#{assigns.item.id}_#{assigns.name}")
       |> assign_new(:valid, fn -> true end)
 
     ~H"""

--- a/lib/backpex/fields/text.ex
+++ b/lib/backpex/fields/text.ex
@@ -56,7 +56,10 @@ defmodule Backpex.Fields.Text do
 
   @impl Backpex.Field
   def render_index_form(assigns) do
-    assigns = assign_new(assigns, :valid, fn -> true end)
+    assigns =
+      assigns
+      |> assign(:input_id, "index_input_#{assigns.item.id}")
+      |> assign_new(:valid, fn -> true end)
 
     ~H"""
     <div>
@@ -75,7 +78,8 @@ defmodule Backpex.Fields.Text do
           class: ["input input-sm", if(@valid, do: "hover:input-bordered", else: "input-error")],
           value: @value,
           phx_debounce: "100",
-          readonly: @readonly
+          readonly: @readonly,
+          id: @input_id
         ) %>
       </.form>
     </div>


### PR DESCRIPTION
closes #61 

We now assign a unique identifier to each index form input based on the item id and the field name.