### PR TITLE
Change artity of init_change function and pass assigns

### DIFF
--- a/demo/lib/demo/tag.ex
+++ b/demo/lib/demo/tag.ex
@@ -22,7 +22,7 @@ defmodule Demo.Tag do
     |> validate_required(@required_fields)
   end
 
-  def create_changeset(category, attrs, metadata) do
+  def create_changeset(category, attrs, _metadata \\ []) do
     category
     |> cast(attrs, @required_fields)
     |> validate_required(@required_fields)

--- a/demo/lib/demo_web/item_actions/duplicate_tag.ex
+++ b/demo/lib/demo_web/item_actions/duplicate_tag.ex
@@ -22,8 +22,6 @@ defmodule DemoWeb.ItemActions.DuplicateTag do
           placeholder: "Tag name"
         }
       ]
-
-      # DemoWeb.TagLive.fields()
     end
 
     @impl Backpex.ItemAction
@@ -33,14 +31,14 @@ defmodule DemoWeb.ItemActions.DuplicateTag do
     def confirm(_assigns), do: "Please complete the form to duplicate the item."
 
     @impl Backpex.ItemAction
-    def confirm_label(assigns), do: "Duplicate"
+    def confirm_label(_assigns), do: "Duplicate"
 
     @impl Backpex.ItemAction
-    def cancel_label(assigns), do: "Cancel"
+    def cancel_label(_assigns), do: "Cancel"
 
     @impl Backpex.ItemAction
-    def changeset(item, change, target, assigns) do
-      Demo.Tag.create_changeset(item, change)
+    def changeset(item, change, metadata) do
+      Demo.Tag.create_changeset(item, change, metadata)
     end
 
     @impl Backpex.ItemAction
@@ -51,7 +49,7 @@ defmodule DemoWeb.ItemActions.DuplicateTag do
     end
 
     @impl Backpex.ItemAction
-    def handle(socket, [item | _items] = items, params) do
+    def handle(socket, _items, params) do
       result =
         %Demo.Tag{}
         |> Demo.Tag.create_changeset(params, [target: nil, assigns: socket.assigns])
@@ -59,7 +57,7 @@ defmodule DemoWeb.ItemActions.DuplicateTag do
 
       socket =
         case result do
-          {:ok, created} ->
+          {:ok, _created} ->
             put_flash(socket, :info, "Item has been duplicated.")
 
           _error ->

--- a/demo/lib/demo_web/item_actions/soft_delete.ex
+++ b/demo/lib/demo_web/item_actions/soft_delete.ex
@@ -28,7 +28,7 @@ defmodule DemoWeb.ItemActions.SoftDelete do
   @required_fields ~w[reason]a
 
   @impl Backpex.ItemAction
-  def changeset(change, attrs, metadata) do
+  def changeset(change, attrs, _metadata) do
     change
     |> cast(attrs, @required_fields)
     |> validate_required(@required_fields)

--- a/demo/lib/demo_web/item_actions/soft_delete.ex
+++ b/demo/lib/demo_web/item_actions/soft_delete.ex
@@ -28,7 +28,7 @@ defmodule DemoWeb.ItemActions.SoftDelete do
   @required_fields ~w[reason]a
 
   @impl Backpex.ItemAction
-  def changeset(change, attrs, _metadata) do
+  def changeset(change, attrs, metadata) do
     change
     |> cast(attrs, @required_fields)
     |> validate_required(@required_fields)

--- a/guides/upgrading/v0.2.md
+++ b/guides/upgrading/v0.2.md
@@ -12,6 +12,30 @@ Update Backpex to the latest version:
   end
 ```
 
+## Pass `assigns` to `init_change` functions
+
+We change the arity of the `init_change/0` function to `init_change/1` for resource and item actions.
+
+The param will be the assigns. This adds more ways to construct an initial change.
+
+If you had such a function in your resource or item action:
+
+```elixir
+@impl Backpex.ItemAction
+def init_change() do
+  # construct init change
+end
+```
+
+You need to change it to this:
+
+```elixir
+@impl Backpex.ItemAction
+def init_change(_assigns) do
+  # construct init change
+end
+```
+
 ## Change arity of changeset functions
 
 See [Pull Request](https://github.com/naymspace/backpex/pull/94).

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -137,7 +137,7 @@ defmodule Backpex.ItemAction do
   This function is optional and can be used to use changesets with schemas in item actions. If this function
   is not provided a changeset will be generated automatically based on the provided types in `Backpex.ItemAction.fields/0`.
   """
-  @callback init_change() ::
+  @callback init_change(assigns :: map()) ::
               Ecto.Schema.t()
               | Ecto.Changeset.t()
               | {Ecto.Changeset.data(), Ecto.Changeset.types()}
@@ -199,7 +199,7 @@ defmodule Backpex.ItemAction do
       @behaviour Backpex.ItemAction
 
       @impl Backpex.ItemAction
-      def init_change do
+      def init_change(_assigns) do
         types = Backpex.Field.changeset_types(fields())
 
         {%{}, types}
@@ -219,7 +219,12 @@ defmodule Backpex.ItemAction do
       def fields, do: []
 
       @impl Backpex.ItemAction
-      def changeset(_change, _attrs, _metadata), do: Ecto.Changeset.change(init_change())
+      def changeset(_change, _attrs, metadata) do
+        assigns = Keyword.get(metadata, :assigns)
+
+        init_change(assigns)
+        |> Ecto.Changeset.change()
+      end
     end
   end
 end

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -50,7 +50,7 @@ defmodule Backpex.FormComponent do
   end
 
   defp assign_changeset(%{assigns: %{action_to_confirm: action_to_confirm}} = socket) do
-    init_change = action_to_confirm.module.init_change()
+    init_change = action_to_confirm.module.init_change(socket.assigns)
     changeset_function = &action_to_confirm.module.changeset/3
 
     socket

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -900,7 +900,7 @@ defmodule Backpex.LiveResource do
           |> assign(:page_title, ResourceAction.name(action, :title))
           |> assign(:resource_action, action)
           |> assign(:resource_action_id, id)
-          |> assign(:item, action.module.init_change())
+          |> assign(:item, action.module.init_change(socket.assigns))
           |> apply_index()
           |> assign(:changeset_function, &action.module.changeset/3)
           |> assign_changeset(action.module.fields())

--- a/lib/backpex/resource_action.ex
+++ b/lib/backpex/resource_action.ex
@@ -73,7 +73,7 @@ defmodule Backpex.ResourceAction do
   This function is optional and can be used to use changesets with schemas in resource actions. If this function
   is not provided a changeset will be generated automatically based on the provided types in `Backpex.ResourceAction.fields/0`.
   """
-  @callback init_change() ::
+  @callback init_change(assigns :: map()) ::
               Ecto.Schema.t()
               | Ecto.Changeset.t()
               | {Ecto.Changeset.data(), Ecto.Changeset.types()}
@@ -112,7 +112,7 @@ defmodule Backpex.ResourceAction do
       @behaviour Backpex.ResourceAction
 
       @impl Backpex.ResourceAction
-      def init_change do
+      def init_change(_assigns) do
         types = Backpex.Field.changeset_types(fields())
 
         {%{}, types}


### PR DESCRIPTION
With this PR we change the arity of the `init_change/0` function to `init_change/1` for resource and item actions.

The param will be the assigns. This adds more ways to construct an initial change.