### PR TITLE
Improve ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
   release:
     types: [published]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,8 @@ jobs:
 
   build-runtime:
     name: "Build runtime"
-    runs-on: ubuntu-latest
-    needs: [lint-demo, test-compile, test-demo, deps-audit]
+    runs-on: docker:git
+    # needs: [lint-demo, test-compile, test-demo, deps-audit]
 
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,11 +121,11 @@ jobs:
 
       - name: Determine the elixir version
         id: elixir_version
-        run: echo "::set-output name=version::$(grep -h elixir .tool-versions | awk '{ print $2 }' | awk -F - '{print $1}')"
+        run: echo "{version}={grep -h elixir .tool-versions | awk '{ print $2 }' | awk -F - '{print $1}'}" >> $GITHUB_OUTPUT
 
       - name: Determine the otp version
         id: otp_version
-        run: echo "::set-output name=version::$(grep -h erlang .tool-versions | awk '{ print $2 }')"
+        run: echo "{version}={grep -h erlang .tool-versions | awk '{ print $2 }'}" >> $GITHUB_OUTPUT
 
       - name: Use versions
         run: echo "Using Elixir version ${{ steps.elixir_version.outputs.version }} and OTP version ${{ steps.otp_version.outputs.version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,35 +121,39 @@ jobs:
 
   test-demo:
     needs: build-demo-testing
-    name: "Test demo"
+    name: "Lint demo"
     runs-on: ubuntu-latest
-    container:
-      # we need to get the image by the output of the previous job because
-      # we can not acces envs here 
-      image: ${{ needs.build-demo-testing.outputs.image }}
   
     steps:
-      - name: Run hex info
-        run: |
-          mix hex.info
+      - name: "Run linter inside demo testing image"
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ needs.build-demo-testing.outputs.image }}
+          run: |
+            cd /opt/app
+            yarn lint:mix
 
-      - name: Debug
-        run: |
-          pwd
-          ls -la
+      # - name: Run hex info
+      #   run: |
+      #     mix hex.info
 
-      - name: Run linters
-        run: |
-          cd /opt/app
-          yarn lint
-          yarn lint:mix
-          yarn lint:dialyzer
-          yarn lint:credo
-          yarn lint:sobelow
-          yarn lint:style
-          yarn lint:standard
-          yarn lint:deps-unused
-          yarn lint:gettext
+      # - name: Debug
+      #   run: |
+      #     pwd
+      #     ls -la
+
+      # - name: Run linters
+      #   run: |
+      #     cd /opt/app
+      #     yarn lint
+      #     yarn lint:mix
+      #     yarn lint:dialyzer
+      #     yarn lint:credo
+      #     yarn lint:sobelow
+      #     yarn lint:style
+      #     yarn lint:standard
+      #     yarn lint:deps-unused
+      #     yarn lint:gettext
 
   build-demo-runtime:
     name: "Build and push demo runtime image"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,13 +133,9 @@ jobs:
         run: |
           mix hex.info
 
-      # - name: Test
-      #   working-directory: /opt/app
-      #   run: |
-      #     yarn test
-
       - name: Run linters
         run: |
+          ls -l
           cd /opt/app
           yarn lint
           yarn lint:mix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           mix gettext.extract --check-up-to-date
 
   build-demo:
-    name: "Build and push demo"
+    name: "Build and push demo testing"
     runs-on: ubuntu-latest
 
     permissions:
@@ -117,7 +117,7 @@ jobs:
           build-args: |
             MIX_ENV=test
     outputs:
-      image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_TESTING }}
+      image: ${{ steps.meta.outputs.tags }}
 
   test-demo:
     needs: build-demo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,42 +129,56 @@ jobs:
       image: ${{ needs.build-demo.outputs.image }}
   
     steps:
+      - name: Run hex info
+        run: |
+          mix hex.info
+
       - name: Test
+        working-directory: /opt/app
         run: |
           yarn test
 
       - name: lint
+        working-directory: /opt/app
         run: |
           yarn lint
 
       - name: lint:mix
+        working-directory: /opt/app
         run: |
           yarn lint:mix
           
       - name: lint:dialyzer
+        working-directory: /opt/app  
         run: |
-          yarn lint:dialyzer
+            yarn lint:dialyzer
 
       - name: lint:credo
+        working-directory: /opt/app
         run: |
           yarn lint:credo
 
       - name: lint:sobelow
+        working-directory: /opt/app
         run: |
           yarn lint:sobelow
 
       - name: lint:style
+        working-directory: /opt/app
         run: |
           yarn lint:style
           
       - name: lint:standard
+        working-directory: /opt/app
         run: |
           yarn lint:standard
 
       - name: lint:deps-unused
+        working-directory: /opt/app
         run: |
           yarn lint:deps-unused
           
       - name: lint:gettext
+        working-directory: /opt/app
         run: |
           yarn lint:gettext

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,6 @@ jobs:
       image: ${{ needs.build-demo-testing.outputs.image }}
   
     steps:
-      - name: lint
-        working-directory: /opt/app/demo
-        run: |
-          yarn lint
-
       - name: lint:mix
         working-directory: /opt/app/demo
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
 
   build-runtime:
     name: "Build runtime"
-    runs-on: docker:git
+    runs-on: ubuntu-latest
     # needs: [lint-demo, test-compile, test-demo, deps-audit]
 
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 
 on:
-    push:
-    release:
-      types: [published]
+  push:
+  release:
+    types: [published]
 
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           path: |
             deps
             _build
+            priv/plts
           key: deps-${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
           restore-keys: |
             deps-${{ runner.os }}-mix-
@@ -55,6 +56,9 @@ jobs:
       - name: Compile with warnings as errors
         run: |
           mix compile --warnings-as-errors --force
+
+      - name: Copy PLTs to priv/plts
+        run: cp priv/plts ${{ github.workspace }}/priv/plts
 
       - name: Dialyzer
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the container registry
         uses: docker/login-action@v3
         with:
@@ -209,6 +212,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the container registry
         uses: docker/login-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
           path: |
             deps
             _build
-            .mix
           key: deps-${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
           restore-keys: |
             deps-${{ runner.os }}-mix-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           target: builder
           build-args: |
             MIX_ENV=test
@@ -227,6 +229,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           target: runtime
           build-args: |
             MIX_ENV=prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.erlang }}-build-
 
+      - name: Restore the plts cache
+        uses: actions/cache@v4
+        id: plts-cache
+        with:
+          path: priv/plts
+          key: ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.erlang }}-plts-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.erlang }}-plts-
+
       - name: Install dependencies
         if: steps.deps-cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,13 @@ jobs:
     services:
       postgres:
         image: postgres:14-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,10 +191,13 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.build-testing.outputs.image }}
+      env:
+        POSTGRES_DB: test
+        POSTGRES_PASSWORD: postgres
     services:
       postgres:
         image: postgres:14-alpine
-        
+
     steps:
       - name: Run test
         working-directory: /opt/app/demo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
         id: plts-cache
         with:
           path: /opt/app/demo/priv/plts
-          key: ${{ runner.os }}-demo-plts-mixlockhash-${{ hashFiles('/opt/app/demo/mix.lock') }}
+          key: ${{ runner.os }}-demo-plts-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/opt/app/demo/mix.lock')) }}
           restore-keys: |
             ${{ runner.os }}-demo-plts-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,6 @@ jobs:
         run: |
           mix compile --warnings-as-errors --force
 
-      - name: Copy PLTs to priv/plts
-        run: cp priv/plts ${{ github.workspace }}/priv/plts
-
       - name: Dialyzer
         run: |
           mix dialyzer --force-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,9 +133,13 @@ jobs:
         run: |
           mix hex.info
 
+      - name: Debug
+        run: |
+          pwd
+          ls -la
+
       - name: Run linters
         run: |
-          ls -l
           cd /opt/app
           yarn lint
           yarn lint:mix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,24 +114,29 @@ jobs:
     needs: test
     name: "Publish package on hex.pm"
     runs-on: ubuntu-latest
-    if: github.event_name == 'release'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Determine the elixir version
-        run: echo "ELIXIR_VERSION=$(grep -h elixir .tool-versions | awk '{ print $2 }' | awk -F - '{print $1}')" >> $GITHUB_ENV
+        id: elixir_version
+        run: echo "::set-output name=version::$(grep -h elixir .tool-versions | awk '{ print $2 }' | awk -F - '{print $1}')"
 
       - name: Determine the otp version
-        run: echo "OTP_VERSION=$(grep -h erlang .tool-versions | awk '{ print $2 }')" >> $GITHUB_ENV
+        id: otp_version
+        run: echo "::set-output name=version::$(grep -h erlang .tool-versions | awk '{ print $2 }')"
+
+      - name: Use versions
+        run: echo "Using Elixir version ${{ steps.elixir_version.outputs.version }} and OTP version ${{ steps.otp_version.outputs.version }}"
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{ env.OTP_VERSION }}
-          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ steps.elixir_version.outputs.version }}
+          elixir-version: ${{ steps.otp_version.outputs.version }}
 
       - name: Publish package on hex.pm
+        if: github.event_name == 'release'
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
         run: mix hex.publish --yes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ['1.15.7']
-        erlang: ['26.1.2']
+        elixir: ['1.15.7', '1.16.1']
+        erlang: ['26.1.2', '26.2.1']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            --target builder
+            --build-arg MIX_ENV=test
     outputs:
       image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_TESTING }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_TESTING }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_TESTING }}:buildcache,mode=max
           target: builder
           build-args: |
             MIX_ENV=test
@@ -281,8 +281,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUNTIME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUNTIME }}:buildcache,mode=max
           target: runtime
           build-args: |
             MIX_ENV=prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,6 @@ jobs:
     name: "Lint demo"
     runs-on: ubuntu-latest
     container:
-      # we need to get the image by the output of the previous job because
-      # we can not acces envs here 
       image: ${{ needs.build-testing.outputs.image }}
   
     steps:
@@ -174,26 +172,48 @@ jobs:
         run: |
           yarn lint:gettext
 
-  test-demo:
+  test-compile:
     needs: build-testing
-    name: "Test demo"
+    name: "Test compile"
     runs-on: ubuntu-latest
     container:
-      # we need to get the image by the output of the previous job because
-      # we can not acces envs here 
       image: ${{ needs.build-testing.outputs.image }}
-    
+
     steps:
       - name: Compile with warnings as errors
         working-directory: /opt/app/demo
         run: |
           mix compile --warnings-as-errors --force
 
+  test-demo:
+    needs: build-testing
+    name: "Test demo"
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.build-testing.outputs.image }}
+    services:
+      postgres:
+        image: postgres:14-alpine
+      options: >-
+        --health-cmd pg_isready
+        --health-interval 10s
+        --health-timeout 5s 
+        --health-retries 5
+
+    steps:
       - name: Run test
         working-directory: /opt/app/demo
         run: |
           yarn test
 
+  deps-audit:
+    needs: build-testing
+    name: "Deps audit"
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.build-testing.outputs.image }}
+
+    steps:
       - name: Deps audit
         working-directory: /opt/app/demo
         continue-on-error: true
@@ -203,7 +223,7 @@ jobs:
   build-runtime:
     name: "Build runtime"
     runs-on: ubuntu-latest
-    needs: [test-demo, lint-demo]
+    needs: [lint-demo, test-compile, test-demo, deps-audit]
 
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
             deps
             _build
             priv/plts
-          key: deps-${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             deps-${{ runner.os }}-mix-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           elixir-version: ${{ matrix.elixir }}
 
       - name: Restore deps and _build cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: |
             deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       
-      - name: Setup Elixir
-        uses: actions/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.erlang }}
           elixir-version: ${{ matrix.elixir }}
-  
+
       - name: Restore deps and _build cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
         run: mix hex.publish --yes
 
   publish:
+    needs: test
     name: "Publish package on hex.pm"
     runs-on: ubuntu-latest
     if: github.event_name == 'release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,8 @@ jobs:
         run: |
           mix gettext.extract --check-up-to-date
 
-  build-demo-testing:
-    name: "Build and push demo testing image"
+  build-testing:
+    name: "Build testing"
     runs-on: ubuntu-latest
 
     permissions:
@@ -120,13 +120,13 @@ jobs:
       image: ${{ steps.meta.outputs.tags }}
 
   lint-demo:
-    needs: build-demo-testing
+    needs: build-testing
     name: "Lint demo"
     runs-on: ubuntu-latest
     container:
       # we need to get the image by the output of the previous job because
       # we can not acces envs here 
-      image: ${{ needs.build-demo-testing.outputs.image }}
+      image: ${{ needs.build-testing.outputs.image }}
   
     steps:
       - name: lint:mix
@@ -170,13 +170,13 @@ jobs:
           yarn lint:gettext
 
   test-demo:
-    needs: build-demo-testing
+    needs: build-testing
     name: "Test demo"
     runs-on: ubuntu-latest
     container:
       # we need to get the image by the output of the previous job because
       # we can not acces envs here 
-      image: ${{ needs.build-demo-testing.outputs.image }}
+      image: ${{ needs.build-testing.outputs.image }}
     
     steps:
       - name: Compile with warnings as errors
@@ -195,8 +195,8 @@ jobs:
         run: |
           mix deps.audit
 
-  build-demo-runtime:
-    name: "Build and push demo runtime image"
+  build-runtime:
+    name: "Build runtime"
     runs-on: ubuntu-latest
     needs: [test-demo, lint-demo]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,8 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{ steps.elixir_version.outputs.version }}
-          elixir-version: ${{ steps.otp_version.outputs.version }}
+          otp-version: ${{ steps.otp_version.outputs.version }}
+          elixir-version: ${{ steps.elixir_version.outputs.version }}
 
       - name: Publish package on hex.pm
         if: github.event_name == 'release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           mix deps.unlock --check-unused
 
       - name: Deps Audit 
+        continue-on-error: true
         run: |
           mix deps.audit
       
@@ -168,9 +169,36 @@ jobs:
         run: |
           yarn lint:gettext
 
+  test-demo:
+    needs: build-demo-testing
+    name: "Test demo"
+    runs-on: ubuntu-latest
+    container:
+      # we need to get the image by the output of the previous job because
+      # we can not acces envs here 
+      image: ${{ needs.build-demo-testing.outputs.image }}
+    
+    steps:
+      - name: Compile with warnings as errors
+        working-directory: /opt/app/demo
+        run: |
+          mix compile --warnings-as-errors --force
+
+      - name: Run test
+        working-directory: /opt/app/demo
+        run: |
+          yarn test
+
+      - name: Deps audit
+        working-directory: /opt/app/demo
+        continue-on-error: true
+        run: |
+          mix deps.audit
+
   build-demo-runtime:
     name: "Build and push demo runtime image"
     runs-on: ubuntu-latest
+    needs: [test-demo, lint-demo]
 
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
 
   test-compile:
     needs: build-testing
-    name: "Test compile"
+    name: "Test compile demo"
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.build-testing.outputs.image }}
@@ -187,7 +187,7 @@ jobs:
 
   test-demo:
     needs: build-testing
-    name: "Test demo"
+    name: "Run tests demo"
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.build-testing.outputs.image }}
@@ -213,7 +213,7 @@ jobs:
 
   deps-audit:
     needs: build-testing
-    name: "Deps audit"
+    name: "Audit deps demo"
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.build-testing.outputs.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,19 @@ jobs:
         run: |
           yarn lint:mix
           
+      - name: Add tar that supports --posix option to be used by cache action
+        run: |
+          apk add --no-cache tar
+
+      - name: Restore the plts cache
+        uses: actions/cache@v4
+        id: plts-cache
+        with:
+          path: /opt/app/demo/priv/plts
+          key: ${{ runner.os }}-demo-plts-mixlockhash-${{ hashFiles('/opt/app/demo/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-demo-plts-
+
       - name: lint:dialyzer
         working-directory: /opt/app/demo  
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,37 @@ jobs:
         run: |
           mix gettext.extract --check-up-to-date
 
+      - name: Publish package on hex.pm
+        if: github.event_name == 'release'
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+        run: mix hex.publish --yes
+
+  publish:
+    name: "Publish package on hex.pm"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Determine the elixir version
+        run: echo "ELIXIR_VERSION=$(grep -h elixir .tool-versions | awk '{ print $2 }' | awk -F - '{print $1}')" >> $GITHUB_ENV
+
+      - name: Determine the otp version
+        run: echo "OTP_VERSION=$(grep -h erlang .tool-versions | awk '{ print $2 }')" >> $GITHUB_ENV
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Publish package on hex.pm
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+        run: mix hex.publish --yes
+
   build-testing:
     name: "Build testing"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,15 +158,6 @@ jobs:
         run: |
           yarn lint:mix
           
-      - name: Restore the plts cache
-        uses: actions/cache@v4
-        id: plts-cache
-        with:
-          path: /opt/app/demo/priv/plts
-          key: ${{ runner.os }}-demo-plts-mixlockhash-${{ hashFiles('/opt/app/demo/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-demo-plts-
-
       - name: lint:dialyzer
         working-directory: /opt/app/demo  
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
         id: plts-cache
         with:
           path: /opt/app/demo/priv/plts
-          key: ${{ runner.os }}-demo-plts-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/opt/app/demo/mix.lock')) }}
+          key: ${{ runner.os }}-demo-plts-mixlockhash-${{ hashFiles('/opt/app/demo/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-demo-plts-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
   build-runtime:
     name: "Build runtime"
     runs-on: ubuntu-latest
-    # needs: [lint-demo, test-compile, test-demo, deps-audit]
+    needs: [lint-demo, test-compile, test-demo, deps-audit]
 
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,83 @@
 name: CI
 
 on:
-  push:
-  release:
-    types: [published]
+    push:
+    release:
+      types: [published]
+
 
 jobs:
-  ci:
+  test:
+    name: "Test Backpex"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        elixir: ['1.15.7']
+        erlang: ['26.1.2']
+
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: erlef/setup-beam@v1
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      - name: Setup Elixir
+        uses: actions/setup-elixir@v1
         with:
-          otp-version: '26.1.2'
-          elixir-version: '1.15.7'
+          otp-version: ${{ matrix.erlang }}
+          elixir-version: ${{ matrix.elixir }}
+  
+      - name: Restore deps and _build cache
+        uses: actions/cache@v1
+        with:
+          path: |
+            deps
+            _build
+            .mix
+          key: deps-${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          restore-keys: |
+            deps-${{ runner.os }}-mix-
 
-      - name: Install Dependencies
-        run: mix deps.get
+      - name: Install dependencies
+        run: |
+          mix local.hex --force --if-missing
+          mix local.rebar --force --if-missing
+          mix deps.get
+      
+      - name: Run tests
+        run: |
+          mix test
+      
+      - name: Check formatting
+        run: |
+          mix format --check-formatted
+      
+      - name: Compile with warnings as errors
+        run: |
+          mix compile --warnings-as-errors --force
 
-      - name: Check Formatting
-        run: mix format --check-formatted
+      - name: Dialyzer
+        run: |
+          mix dialyzer --force-check
 
-      - name: Run Tests
-        run: mix test
+      - name: Credo
+        run: |
+          mix credo
 
-      - name: Publish package
-        if: github.event_name == 'release'
-        env:
-          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
-        run: mix hex.publish --yes
+      - name: Sobelow
+        run: |
+          mix sobelow --config
+
+      - name: Deps Unused
+        run: |
+          mix deps.unlock --check-unused
+
+      - name: Deps Audit 
+        run: |
+          mix deps.audit
+      
+      - name: Gettext Check
+        run: |
+          mix gettext.extract --check-up-to-date
+
+      - name: Run Demo Tests
+        run: |
+          cd demo && mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          target: builder
           build-args: |
-            --target builder
-            --build-arg MIX_ENV=test
+            MIX_ENV=test
     outputs:
       image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_TESTING }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,49 +138,17 @@ jobs:
       #   run: |
       #     yarn test
 
-      - name: lint
-        working-directory: /opt/app
+      - name: Run linters
         run: |
+          cd /opt/app
           yarn lint
-
-      - name: lint:mix
-        working-directory: /opt/app
-        run: |
           yarn lint:mix
-          
-      - name: lint:dialyzer
-        working-directory: /opt/app  
-        run: |
-            yarn lint:dialyzer
-
-      - name: lint:credo
-        working-directory: /opt/app
-        run: |
+          yarn lint:dialyzer
           yarn lint:credo
-
-      - name: lint:sobelow
-        working-directory: /opt/app
-        run: |
           yarn lint:sobelow
-
-      - name: lint:style
-        working-directory: /opt/app
-        run: |
           yarn lint:style
-          
-      - name: lint:standard
-        working-directory: /opt/app
-        run: |
           yarn lint:standard
-
-      - name: lint:deps-unused
-        working-directory: /opt/app
-        run: |
           yarn lint:deps-unused
-          
-      - name: lint:gettext
-        working-directory: /opt/app
-        run: |
           yarn lint:gettext
 
   build-demo-runtime:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
         run: |
           mix gettext.extract --check-up-to-date
 
-  build-demo:
-    name: "Build and push demo testing"
+  build-demo-testing:
+    name: "Build and push demo testing image"
     runs-on: ubuntu-latest
 
     permissions:
@@ -120,23 +120,23 @@ jobs:
       image: ${{ steps.meta.outputs.tags }}
 
   test-demo:
-    needs: build-demo
+    needs: build-demo-testing
     name: "Test demo"
     runs-on: ubuntu-latest
     container:
       # we need to get the image by the output of the previous job because
       # we can not acces envs here 
-      image: ${{ needs.build-demo.outputs.image }}
+      image: ${{ needs.build-demo-testing.outputs.image }}
   
     steps:
       - name: Run hex info
         run: |
           mix hex.info
 
-      - name: Test
-        working-directory: /opt/app
-        run: |
-          yarn test
+      # - name: Test
+      #   working-directory: /opt/app
+      #   run: |
+      #     yarn test
 
       - name: lint
         working-directory: /opt/app
@@ -182,3 +182,39 @@ jobs:
         working-directory: /opt/app
         run: |
           yarn lint:gettext
+
+  build-demo-runtime:
+    name: "Build and push demo runtime image"
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUNTIME }}
+
+      - name: Build container
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: runtime
+          build-args: |
+            MIX_ENV=prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,22 +28,34 @@ jobs:
           otp-version: ${{ matrix.erlang }}
           elixir-version: ${{ matrix.elixir }}
 
-      - name: Restore deps and _build cache
+      - name: Restore the deps cache
         uses: actions/cache@v4
+        id: deps-cache
         with:
-          path: |
-            deps
-            _build
-            priv/plts
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          path: deps
+          key: ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.erlang }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
           restore-keys: |
-            deps-${{ runner.os }}-mix-
+            ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.erlang }}-deps-
+    
+      - name: Restore the _build cache
+        uses: actions/cache@v4
+        id: build-cache
+        with:
+          path: _build
+          key: ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.erlang }}-build-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.erlang }}-build-
 
       - name: Install dependencies
+        if: steps.deps-cache.outputs.cache-hit != 'true'
         run: |
           mix local.hex --force --if-missing
           mix local.rebar --force --if-missing
           mix deps.get
+
+      - name: Compile dependencies
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: mix deps.compile
       
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,6 @@ jobs:
       - name: Build container
         uses: docker/build-push-action@v5
         with:
-          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -183,7 +182,6 @@ jobs:
       - name: Build container
         uses: docker/build-push-action@v5
         with:
-          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
 
   publish:
     needs: test
+    if: github.event_name == 'release'
     name: "Publish package on hex.pm"
     runs-on: ubuntu-latest
 
@@ -136,7 +137,6 @@ jobs:
           elixir-version: ${{ steps.elixir_version.outputs.version }}
 
       - name: Publish package on hex.pm
-        if: github.event_name == 'release'
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
         run: mix hex.publish --yes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,12 +194,7 @@ jobs:
     services:
       postgres:
         image: postgres:14-alpine
-      options: >-
-        --health-cmd pg_isready
-        --health-interval 10s
-        --health-timeout 5s 
-        --health-retries 5
-
+        
     steps:
       - name: Run test
         working-directory: /opt/app/demo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,41 +118,60 @@ jobs:
     outputs:
       image: ${{ steps.meta.outputs.tags }}
 
-  test-demo:
+  lint-demo:
     needs: build-demo-testing
     name: "Lint demo"
     runs-on: ubuntu-latest
+    container:
+      # we need to get the image by the output of the previous job because
+      # we can not acces envs here 
+      image: ${{ needs.build-demo-testing.outputs.image }}
   
     steps:
-      - name: "Run linter inside demo testing image"
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ needs.build-demo-testing.outputs.image }}
-          run: |
-            cd /opt/app
-            yarn lint:mix
+      - name: lint
+        working-directory: /opt/app/demo
+        run: |
+          yarn lint
 
-      # - name: Run hex info
-      #   run: |
-      #     mix hex.info
+      - name: lint:mix
+        working-directory: /opt/app/demo
+        run: |
+          yarn lint:mix
+          
+      - name: lint:dialyzer
+        working-directory: /opt/app/demo  
+        run: |
+          yarn lint:dialyzer
 
-      # - name: Debug
-      #   run: |
-      #     pwd
-      #     ls -la
+      - name: lint:credo
+        working-directory: /opt/app/demo
+        run: |
+          yarn lint:credo
 
-      # - name: Run linters
-      #   run: |
-      #     cd /opt/app
-      #     yarn lint
-      #     yarn lint:mix
-      #     yarn lint:dialyzer
-      #     yarn lint:credo
-      #     yarn lint:sobelow
-      #     yarn lint:style
-      #     yarn lint:standard
-      #     yarn lint:deps-unused
-      #     yarn lint:gettext
+      - name: lint:sobelow
+        working-directory: /opt/app/demo
+        run: |
+          yarn lint:sobelow
+
+      - name: lint:style
+        working-directory: /opt/app/demo
+        run: |
+          yarn lint:style
+          
+      - name: lint:standard
+        working-directory: /opt/app/demo
+        run: |
+          yarn lint:standard
+
+      - name: lint:deps-unused
+        working-directory: /opt/app/demo
+        run: |
+          yarn lint:deps-unused
+          
+      - name: lint:gettext
+        working-directory: /opt/app/demo
+        run: |
+          yarn lint:gettext
 
   build-demo-runtime:
     name: "Build and push demo runtime image"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
 
   lint-demo:
     needs: build-testing
-    name: "Lint demo"
+    name: "Lint (Demo)"
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.build-testing.outputs.image }}
@@ -208,7 +208,7 @@ jobs:
 
   test-compile:
     needs: build-testing
-    name: "Test compile demo"
+    name: "Compile (Demo)"
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.build-testing.outputs.image }}
@@ -221,7 +221,7 @@ jobs:
 
   test-demo:
     needs: build-testing
-    name: "Run tests demo"
+    name: "Test (Demo)"
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.build-testing.outputs.image }}
@@ -247,7 +247,7 @@ jobs:
 
   deps-audit:
     needs: build-testing
-    name: "Audit deps demo"
+    name: "Deps Audit (Demo)"
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.build-testing.outputs.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,15 @@ jobs:
         run: |
           yarn lint:mix
           
+      - name: Restore the plts cache
+        uses: actions/cache@v4
+        id: plts-cache
+        with:
+          path: /opt/app/demo/priv/plts
+          key: ${{ runner.os }}-demo-plts-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/opt/app/demo/mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-demo-plts-
+
       - name: lint:dialyzer
         working-directory: /opt/app/demo  
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,11 +121,11 @@ jobs:
 
       - name: Determine the elixir version
         id: elixir_version
-        run: echo "{version}={grep -h elixir .tool-versions | awk '{ print $2 }' | awk -F - '{print $1}'}" >> $GITHUB_OUTPUT
+        run: echo "version=$(grep -h elixir .tool-versions | awk '{ print $2 }' | awk -F - '{print $1}')" >> $GITHUB_OUTPUT
 
       - name: Determine the otp version
         id: otp_version
-        run: echo "{version}={grep -h erlang .tool-versions | awk '{ print $2 }'}" >> $GITHUB_OUTPUT
+        run: echo "version=$(grep -h erlang .tool-versions | awk '{ print $2 }')" >> $GITHUB_OUTPUT
 
       - name: Use versions
         run: echo "Using Elixir version ${{ steps.elixir_version.outputs.version }} and OTP version ${{ steps.otp_version.outputs.version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,14 @@ on:
   release:
     types: [published]
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME_TESTING: ${{ github.repository }}/testing
+  IMAGE_NAME_RUNTIME: ${{ github.repository }}/runtime
 
 jobs:
   test:
-    name: "Test Backpex"
+    name: "Test backpex"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -17,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       
       - uses: erlef/setup-beam@v1
         with:
@@ -77,6 +81,87 @@ jobs:
         run: |
           mix gettext.extract --check-up-to-date
 
-      - name: Run Demo Tests
+  build-demo:
+    name: "Build and push demo"
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_TESTING }}
+
+      - name: Build container
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+    outputs:
+      image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_TESTING }}
+
+  test-demo:
+    needs: build-demo
+    name: "Test demo"
+    runs-on: ubuntu-latest
+    container:
+      # we need to get the image by the output of the previous job because
+      # we can not acces envs here 
+      image: ${{ needs.build-demo.outputs.image }}
+  
+    steps:
+      - name: Test
         run: |
-          cd demo && mix test
+          yarn test
+
+      - name: lint
+        run: |
+          yarn lint
+
+      - name: lint:mix
+        run: |
+          yarn lint:mix
+          
+      - name: lint:dialyzer
+        run: |
+          yarn lint:dialyzer
+
+      - name: lint:credo
+        run: |
+          yarn lint:credo
+
+      - name: lint:sobelow
+        run: |
+          yarn lint:sobelow
+
+      - name: lint:style
+        run: |
+          yarn lint:style
+          
+      - name: lint:standard
+        run: |
+          yarn lint:standard
+
+      - name: lint:deps-unused
+        run: |
+          yarn lint:deps-unused
+          
+      - name: lint:gettext
+        run: |
+          yarn lint:gettext

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ['1.15.7', '1.16.1']
-        erlang: ['26.1.2', '26.2.1']
+        elixir: ['1.16.1', '1.15.7']
+        erlang: ['26.2.2', '25.3.2']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
       - name: lint:dialyzer
         working-directory: /opt/app/demo  
         run: |
-          yarn lint:dialyzer
+          mix dialyzer --force-check
 
       - name: lint:credo
         working-directory: /opt/app/demo

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ SHELL ["/bin/bash", "-c"]
 COPY --from=builder /etc/bashrc.d /etc/bashrc.d
 COPY --from=builder /etc/bash.bashrc /etc/bash.bashrc
 COPY --from=builder /opt/scripts /opt/scripts
+COPY .docker/root/.bashrc /root/
 
 RUN chown -R nobody:nobody /opt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,6 @@ SHELL ["/bin/bash", "-c"]
 COPY --from=builder /etc/bashrc.d /etc/bashrc.d
 COPY --from=builder /etc/bash.bashrc /etc/bash.bashrc
 COPY --from=builder /opt/scripts /opt/scripts
-COPY .bashrc /root/
 
 RUN chown -R nobody:nobody /opt
 

--- a/demo/assets/css/app.css
+++ b/demo/assets/css/app.css
@@ -3,7 +3,6 @@
 @import "tailwindcss/utilities";
 
 @layer utilities {
-
   /* LiveView specific classes */
   .phx-no-feedback.invalid-feedback,
   .phx-no-feedback .invalid-feedback {

--- a/demo/assets/tailwind.config.js
+++ b/demo/assets/tailwind.config.js
@@ -31,7 +31,7 @@ module.exports = {
     extend: {
       colors: {
         transparent: 'transparent',
-        current: 'currentColor',
+        current: 'currentColor'
       }
     }
   },

--- a/demo/assets/tailwind.config.js
+++ b/demo/assets/tailwind.config.js
@@ -36,8 +36,8 @@ module.exports = {
     }
   },
   plugins: [
-    require("@tailwindcss/typography"),
-    require("daisyui"),
+    require('@tailwindcss/typography'),
+    require('daisyui'),
     plugin(({ addVariant }) => addVariant('phx-no-feedback', ['.phx-no-feedback&', '.phx-no-feedback &'])),
     plugin(({ addVariant }) => addVariant('phx-click-loading', ['.phx-click-loading&', '.phx-click-loading &'])),
     plugin(({ addVariant }) => addVariant('phx-submit-loading', ['.phx-submit-loading&', '.phx-submit-loading &'])),

--- a/demo/lib/demo/tag.ex
+++ b/demo/lib/demo/tag.ex
@@ -22,7 +22,7 @@ defmodule Demo.Tag do
     |> validate_required(@required_fields)
   end
 
-  def create_changeset(category, attrs, metadata) do
+  def create_changeset(category, attrs, _metadata) do
     category
     |> cast(attrs, @required_fields)
     |> validate_required(@required_fields)

--- a/demo/lib/demo_web/item_actions/duplicate_tag.ex
+++ b/demo/lib/demo_web/item_actions/duplicate_tag.ex
@@ -1,70 +1,69 @@
 defmodule DemoWeb.ItemActions.DuplicateTag do
-    @moduledoc false
+  @moduledoc false
 
-    use BackpexWeb, :item_action
+  use BackpexWeb, :item_action
 
-    alias Demo.Repo
+  alias Demo.Repo
 
-    @impl Backpex.ItemAction
-    def icon(assigns) do
-      ~H"""
-      <Heroicons.document_duplicate class="h-5 w-5 cursor-pointer transition duration-75 hover:scale-110 hover:text-green-600" />
-      """
-    end
+  @impl Backpex.ItemAction
+  def icon(assigns) do
+    ~H"""
+    <Heroicons.document_duplicate class="h-5 w-5 cursor-pointer transition duration-75 hover:scale-110 hover:text-green-600" />
+    """
+  end
 
-    @impl Backpex.ItemAction
-    def fields do
-      [
-        name: %{
-          module: Backpex.Fields.Text,
-          label: "Name",
-          searchable: true,
-          placeholder: "Tag name"
-        }
-      ]
-    end
+  @impl Backpex.ItemAction
+  def fields do
+    [
+      name: %{
+        module: Backpex.Fields.Text,
+        label: "Name",
+        searchable: true,
+        placeholder: "Tag name"
+      }
+    ]
+  end
 
-    @impl Backpex.ItemAction
-    def label(_assigns), do: "Duplicate"
+  @impl Backpex.ItemAction
+  def label(_assigns), do: "Duplicate"
 
-    @impl Backpex.ItemAction
-    def confirm(_assigns), do: "Please complete the form to duplicate the item."
+  @impl Backpex.ItemAction
+  def confirm(_assigns), do: "Please complete the form to duplicate the item."
 
-    @impl Backpex.ItemAction
-    def confirm_label(_assigns), do: "Duplicate"
+  @impl Backpex.ItemAction
+  def confirm_label(_assigns), do: "Duplicate"
 
-    @impl Backpex.ItemAction
-    def cancel_label(_assigns), do: "Cancel"
+  @impl Backpex.ItemAction
+  def cancel_label(_assigns), do: "Cancel"
 
-    @impl Backpex.ItemAction
-    def changeset(item, change, metadata) do
-      Demo.Tag.create_changeset(item, change, metadata)
-    end
+  @impl Backpex.ItemAction
+  def changeset(item, change, metadata) do
+    Demo.Tag.create_changeset(item, change, metadata)
+  end
 
-    @impl Backpex.ItemAction
-    def init_change(assigns) do
-      [item | _other] = assigns.selected_items
+  @impl Backpex.ItemAction
+  def init_change(assigns) do
+    [item | _other] = assigns.selected_items
 
-      item
-    end
+    item
+  end
 
-    @impl Backpex.ItemAction
-    def handle(socket, _items, params) do
-      result =
-        %Demo.Tag{}
-        |> Demo.Tag.create_changeset(params, [target: nil, assigns: socket.assigns])
-        |> Repo.insert()
+  @impl Backpex.ItemAction
+  def handle(socket, _items, params) do
+    result =
+      %Demo.Tag{}
+      |> Demo.Tag.create_changeset(params, target: nil, assigns: socket.assigns)
+      |> Repo.insert()
 
-      socket =
-        case result do
-          {:ok, _created} ->
-            put_flash(socket, :info, "Item has been duplicated.")
+    socket =
+      case result do
+        {:ok, _created} ->
+          put_flash(socket, :info, "Item has been duplicated.")
 
-          _error ->
-            put_flash(socket, :error, "Error while duplicating item.")
-        end
+        _error ->
+          put_flash(socket, :error, "Error while duplicating item.")
+      end
 
-
-      {:noreply, socket}
-    end
+    {:noreply, socket}
+  end
 end


### PR DESCRIPTION
Many improvements for the CI pipeline.

We test Backpex in a separate matrix with different combination of OTP and Elixir version.

Along with that, we build a testing image based on the Dockerfile (`MIX_ENV=test`, `target=runtime`) and mostly use it to test the demo application. We run all lint commands provided in `demo/package.json`, compile the demo application with `--warnings-as-errors`, audit deps and run the tests. If all (demo) testing steps are successful, a runtime image is being built (`MIX_ENV=prod`, `target=runtime`).

The images are hosted in the GitHub Container registry:  https://github.com/orgs/naymspace/packages?repo_name=backpex We use [docker/metadata-action](https://github.com/docker/metadata-action) to label and tag the images. See the [README](https://github.com/docker/metadata-action/blob/master/README.md) of the action for explainations on how images get tagged and labelled in detail.

To sum it up:
| Event               | Ref                           | Docker Tags                |
|---------------------|-------------------------------|----------------------------|
| `pull_request`      | `refs/pull/2/merge`           | `pr-2`                     |
| `push`              | `refs/heads/master`           | `master`                   |
| `push`              | `refs/heads/releases/v1`      | `releases-v1`              |
| `push tag`          | `refs/tags/v1.2.3`            | `v1.2.3`, `latest`         |
| `push tag`          | `refs/tags/v2.0.8-beta.67`    | `v2.0.8-beta.67`, `latest` |
| `workflow_dispatch` | `refs/heads/master`           | `master`                   |

This means after a push to `develop` we have these two images:
- `ghcr.io/naymspace/backpex/testing:develop`
- `ghcr.io/naymspace/backpex/runtime:develop`

After a tag push with the title `0.1.0`:
- `ghcr.io/naymspace/backpex/testing:0.1.0`
- `ghcr.io/naymspace/backpex/runtime:0.1.0`

We use [actions/cache](https://github.com/actions/cache) to cache the `_build`, `deps` and `priv/plts` folder when executing Backpex tests. The cache depends on the Elixir and OTP version combination and the `mix.lock` file.

In addition, we use a registry cache to speed up docker builds. See [Cache management with GitHub Actions](https://docs.docker.com/build/ci/github-actions/cache/#registry-cache) for explanations.

When running the Demo tests, we also use [actions/cache](https://github.com/actions/cache) to cache `priv/plts`. These tests are running inside our container. That's why we have to install `tar` because the version of tar shipped as part of busybox in our container doesn't support the `--posix` option which is used by [actions/cache](https://github.com/actions/cache)

Example pipeline:
![image](https://github.com/naymspace/backpex/assets/60519307/34fed8a2-63c6-4fff-b0f2-1c332e8530a4)

