### PR TITLE
Fix nil value was not properly displayed in select field

### DIFF
--- a/lib/backpex/fields/select.ex
+++ b/lib/backpex/fields/select.ex
@@ -26,15 +26,9 @@ defmodule Backpex.Fields.Select do
   @impl Backpex.Field
   def render_value(assigns) do
     options = Map.get(assigns.field_options, :options)
+    label = get_label(assigns.value, options)
 
-    label =
-      assigns.value
-      |> Atom.to_string()
-      |> get_label(options)
-
-    assigns =
-      assigns
-      |> assign(:label, label)
+    assigns = assign(assigns, :label, label)
 
     ~H"""
     <p class={@live_action in [:index, :resource_action] && "truncate"}>


### PR DESCRIPTION
We used `Atom.to_string` before searching for a label in `Backpex.Fields.Select`. If the value was `nil` this caused the value to become "nil".  When we could not find an option with label "nil" we returned the value itself, so "nil" was displayed on show views.