### PR TITLE
Support index editable for Backpex.Fields.Select

### DIFF
--- a/lib/backpex/fields/select.ex
+++ b/lib/backpex/fields/select.ex
@@ -65,6 +65,48 @@ defmodule Backpex.Fields.Select do
     """
   end
 
+  @impl Backpex.Field
+  def render_index_form(assigns) do
+    options = Map.get(assigns.field_options, :options)
+
+    assigns =
+      assigns
+      |> assign(:input_id, "index_input_#{assigns.item.id}_#{assigns.name}")
+      |> assign_new(:valid, fn -> true end)
+      |> assign(:options, options)
+      |> assign_prompt(assigns.field_options)
+
+    ~H"""
+    <div>
+      <.form
+        :let={f}
+        for={%{}}
+        as={:index_form}
+        class="relative"
+        phx-change="update-field"
+        phx-submit="update-field"
+        phx-target={@myself}
+      >
+        <%= Phoenix.HTML.Form.select(
+          f,
+          :index_input,
+          @options,
+          class: ["select select-sm", if(@valid, do: "hover:input-bordered", else: "select-error")],
+          selected: @value,
+          disabled: @readonly,
+          id: @input_id,
+          prompt: Map.get(@prompt, :prompt)
+        ) %>
+      </.form>
+    </div>
+    """
+  end
+
+  @impl Phoenix.LiveComponent
+  def handle_event("update-field", %{"index_form" => %{"index_input" => value}}, socket) do
+    Backpex.Field.handle_index_editable(socket, %{} |> Map.put(socket.assigns.name, value))
+  end
+
   defp get_label(value, options) do
     case Enum.find(options, fn option -> value?(option, value) end) do
       nil -> value

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -533,8 +533,9 @@ defmodule Backpex.LiveResource do
       end
 
   Currently supported by the following fields:
-  - `Backpex.Fields.Text`
   - `Backpex.Fields.Number`
+  - `Backpex.Fields.Select`
+  - `Backpex.Fields.Text`
 
   > Note you can add index editable support to your custom fields by defining the `render_index_form/1` function and enabling index editable for your field.
   '''


### PR DESCRIPTION
Add `render_index_form` callback in order to support index editable for `Backpex.Fields.Select`