### PR TITLE
Change documentation entry point and add github link to landing page

### DIFF
--- a/demo/lib/demo_web/live/home_live/index.html.heex
+++ b/demo/lib/demo_web/live/home_live/index.html.heex
@@ -29,7 +29,10 @@
         <.link navigate="/admin/users" class="mr-6">
           <button class="btn btn-primary">View Demo</button>
         </.link>
-        <.link href="https://github.com/naymspace/backpex" class="text-sm font-semibold leading-6 text-gray-900 hover:underline">
+        <.link
+          href="https://github.com/naymspace/backpex"
+          class="text-sm font-semibold leading-6 text-gray-900 hover:underline"
+        >
           GitHub
         </.link>
         <Heroicons.arrow_right class="ml-2 h-4 w-4" />

--- a/demo/lib/demo_web/live/home_live/index.html.heex
+++ b/demo/lib/demo_web/live/home_live/index.html.heex
@@ -29,8 +29,8 @@
         <.link navigate="/admin/users" class="mr-6">
           <button class="btn btn-primary">View Demo</button>
         </.link>
-        <.link href="https://hexdocs.pm/backpex" class="text-sm font-semibold leading-6 text-gray-900 hover:underline">
-          Documentation
+        <.link href="https://github.com/naymspace/backpex" class="text-sm font-semibold leading-6 text-gray-900 hover:underline">
+          GitHub
         </.link>
         <Heroicons.arrow_right class="ml-2 h-4 w-4" />
       </div>

--- a/mix.exs
+++ b/mix.exs
@@ -68,6 +68,7 @@ defmodule Backpex.MixProject do
 
   defp docs() do
     [
+      main: "Backpex.LiveResource",
       logo: "priv/static/images/logo.svg",
       extras: extras(),
       extra_section: "GUIDES",


### PR DESCRIPTION
- Change documentation entry point to `Backpex.LiveResource` module
- Replace documentation link with GitHub link on landing page

![image](https://github.com/naymspace/backpex/assets/60519307/4a9aa5f9-ba0d-4362-ab63-d3697cdfaeb6)
