### PR TITLE
Fix custom alias causes nil bindings in query

### DIFF
--- a/lib/backpex/resource.ex
+++ b/lib/backpex/resource.ex
@@ -178,7 +178,7 @@ defmodule Backpex.Resource do
   def apply_criteria(query, criteria, fields) do
     Enum.reduce(criteria, query, fn
       {:order, %{by: by, direction: direction, schema: schema, field_name: field_name}}, query ->
-        schema_name = get_custom_alias(fields, name_by_schema(schema), field_name)
+        schema_name = get_custom_alias(fields, field_name, name_by_schema(schema))
 
         direction =
           case direction do
@@ -219,13 +219,13 @@ defmodule Backpex.Resource do
     end)
   end
 
-  defp get_custom_alias(fields, schema, field_name) do
+  defp get_custom_alias(fields, field_name, default_alias) do
     case Keyword.get(fields, field_name) do
       %{custom_alias: custom_alias} ->
         custom_alias
 
       _field_or_nil ->
-        schema
+        default_alias
     end
   end
 

--- a/lib/backpex/resource.ex
+++ b/lib/backpex/resource.ex
@@ -224,7 +224,7 @@ defmodule Backpex.Resource do
       %{custom_alias: custom_alias} ->
         custom_alias
 
-      _field ->
+      _field_or_nil ->
         schema
     end
   end

--- a/lib/backpex/resource.ex
+++ b/lib/backpex/resource.ex
@@ -180,8 +180,6 @@ defmodule Backpex.Resource do
       {:order, %{by: by, direction: direction, schema: schema, field_name: field_name}}, query ->
         schema_name = get_custom_alias(fields, name_by_schema(schema))
 
-        IO.inspect(schema_name, label: :schema_name_debug)
-
         direction =
           case direction do
             :desc -> :desc_nulls_last

--- a/lib/backpex/resource.ex
+++ b/lib/backpex/resource.ex
@@ -180,6 +180,8 @@ defmodule Backpex.Resource do
       {:order, %{by: by, direction: direction, schema: schema, field_name: field_name}}, query ->
         schema_name = get_custom_alias(fields, name_by_schema(schema))
 
+        IO.inspect(schema_name, label: :schema_name_debug)
+
         direction =
           case direction do
             :desc -> :desc_nulls_last
@@ -220,9 +222,13 @@ defmodule Backpex.Resource do
   end
 
   defp get_custom_alias(fields, schema) do
-    fields
-    |> Keyword.get(schema, %{custom_alias: schema})
-    |> Map.get(:custom_alias)
+    case Keyword.get(fields, schema) do
+      %{custom_alias: custom_alias} ->
+        custom_alias
+
+      _field ->
+        schema
+    end
   end
 
   @doc """

--- a/lib/backpex/resource.ex
+++ b/lib/backpex/resource.ex
@@ -178,7 +178,7 @@ defmodule Backpex.Resource do
   def apply_criteria(query, criteria, fields) do
     Enum.reduce(criteria, query, fn
       {:order, %{by: by, direction: direction, schema: schema, field_name: field_name}}, query ->
-        schema_name = get_custom_alias(fields, name_by_schema(schema))
+        schema_name = get_custom_alias(fields, name_by_schema(schema), field_name)
 
         direction =
           case direction do
@@ -219,8 +219,8 @@ defmodule Backpex.Resource do
     end)
   end
 
-  defp get_custom_alias(fields, schema) do
-    case Keyword.get(fields, schema) do
+  defp get_custom_alias(fields, schema, field_name) do
+    case Keyword.get(fields, field_name) do
       %{custom_alias: custom_alias} ->
         custom_alias
 


### PR DESCRIPTION
If a field is found by `get_custom_alias` and no `custom_alias` is defined for that field, the function will return `nil`, which in some cases will break the query (e.g., if no `select` option is defined).