### PR TITLE
Fix filter label is not displayed with atom values in filter options

### DIFF
--- a/lib/backpex/filters/boolean.ex
+++ b/lib/backpex/filters/boolean.ex
@@ -145,7 +145,7 @@ defmodule Backpex.Filters.Boolean do
 
   def find_option_label(options, key) do
     Enum.find_value(options, fn option ->
-      if option.key == key, do: option.label
+      if to_string(option.key) == to_string(key), do: option.label
     end) || ""
   end
 

--- a/lib/backpex/filters/multi_select.ex
+++ b/lib/backpex/filters/multi_select.ex
@@ -147,7 +147,7 @@ defmodule Backpex.Filters.MultiSelect do
 
   def find_option_label(options, key) do
     Enum.find_value(options, fn {l, k} ->
-      if k == key, do: l
+      if to_string(k) == to_string(key), do: l
     end) || ""
   end
 end

--- a/lib/backpex/filters/select.ex
+++ b/lib/backpex/filters/select.ex
@@ -110,7 +110,7 @@ defmodule Backpex.Filters.Select do
 
   def option_value_to_label(options, value) do
     Enum.find_value(options, fn {option_label, option_value} ->
-      if option_value == value, do: option_label
+      if to_string(option_value) == to_string(value), do: option_label
     end)
   end
 end


### PR DESCRIPTION
If atoms were used as filter values, the filter label was not shown. This error occurred because we tried to compare atoms with strings in this case.