### PR TITLE
Make filter label configurable in filter definition

### DIFF
--- a/demo/lib/demo_web/live/post_live.ex
+++ b/demo/lib/demo_web/live/post_live.ex
@@ -20,13 +20,16 @@ defmodule DemoWeb.PostLive do
   def filters do
     [
       category_id: %{
-        module: DemoWeb.Filters.PostCategorySelect
+        module: DemoWeb.Filters.PostCategorySelect,
+        label: "Category"
       },
       user_id: %{
-        module: DemoWeb.Filters.PostUserMultiSelect
+        module: DemoWeb.Filters.PostUserMultiSelect,
+        label: "Users"
       },
       likes: %{
         module: DemoWeb.Filters.PostLikeRange,
+        label: "Likes",
         presets: [
           %{
             label: "Over 100",
@@ -40,6 +43,7 @@ defmodule DemoWeb.PostLive do
       },
       inserted_at: %{
         module: DemoWeb.Filters.DateTimeRange,
+        label: "Created at",
         presets: [
           %{
             label: "Last 7 Days",
@@ -72,6 +76,7 @@ defmodule DemoWeb.PostLive do
       },
       published: %{
         module: DemoWeb.Filters.PostPublished,
+        label: "Published?",
         default: ["published"],
         presets: [
           %{

--- a/demo/lib/demo_web/live/product_live.ex
+++ b/demo/lib/demo_web/live/product_live.ex
@@ -19,7 +19,8 @@ defmodule DemoWeb.ProductLive do
   def filters do
     [
       quantity: %{
-        module: DemoWeb.Filters.ProductQuantityRange
+        module: DemoWeb.Filters.ProductQuantityRange,
+        label: "Quantity"
       }
     ]
   end

--- a/lib/backpex/filters/filter.ex
+++ b/lib/backpex/filters/filter.ex
@@ -27,7 +27,7 @@ defmodule Backpex.Filter do
 
   ## Custom filters
 
-  Instead of using the pre-defined filters you can also define custom filters by using `Backpex.Filter` and implementing at least `label/0`, `query/3`, `render/1` and `render_form/1`.
+  Instead of using the pre-defined filters you can also define custom filters by using `Backpex.Filter` and implementing at least `query/3`, `render/1` and `render_form/1`.
 
   For example purposes let's define a custom select filter:
 
@@ -45,7 +45,7 @@ defmodule Backpex.Filter do
           <%= @label %>
           """
         end
-      
+
         @impl Backpex.Filter
         def render_form(assigns) do
           ~H"""
@@ -59,18 +59,18 @@ defmodule Backpex.Filter do
           />
           """
         end
-        
+
         @impl Backpex.Filter
         def query(query, attribute, value) do
           where(query, [x], field(x, ^attribute) == ^value)
         end
-        
+
         defp option_value_to_label(options, value) do
           Enum.find_value(options, fn {option_label, option_value} ->
             if option_value == value, do: option_label
           end)
         end
-        
+
         defp my_options, do: [
           {"Select an option...", nil},
           {"Open", :open},
@@ -96,6 +96,7 @@ defmodule Backpex.Filter do
       def filters, do: [
           begins_at: %{
             module: MyAppWeb.Filters.DateRange,
+            label: "Begins At",
             presets: [
             %{
               label: "Last 7 Days",
@@ -128,7 +129,7 @@ defmodule Backpex.Filter do
   @callback can?(Phoenix.LiveView.Socket.assigns()) :: boolean()
 
   @doc """
-  The filter's label.
+  If no label is defined on the filter map, this value is used as the filter label.
   """
   @callback label :: String.t()
 
@@ -146,6 +147,8 @@ defmodule Backpex.Filter do
   Renders the filters options form.
   """
   @callback render_form(Phoenix.LiveView.Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
+
+  @optional_callbacks label: 0
 
   defmacro __using__(_opts) do
     quote do

--- a/lib/backpex/html/resource.ex
+++ b/lib/backpex/html/resource.ex
@@ -251,7 +251,7 @@ defmodule Backpex.HTML.Resource do
     ~H"""
     <div class="join relative ring-1 ring-gray-400">
       <div class="badge badge-outline join-item h-auto border-0 bg-gray-200 px-4 py-1.5 font-semibold">
-        <%= @filter.module.label() %>
+        <%= Map.get(@filter, :label, @filter.module.label()) %>
       </div>
       <div class="badge badge-outline join-item h-auto border-0 px-4 py-1.5">
         <%= component(
@@ -281,7 +281,7 @@ defmodule Backpex.HTML.Resource do
         <.form :let={f} for={to_form(%{}, as: :filters)} phx-change="change-filter" phx-submit="change-filter">
           <div>
             <div class="relative flex w-full flex-wrap justify-start gap-2">
-              <div class="text-sm font-medium text-gray-900"><%= filter.module.label() %></div>
+              <div class="text-sm font-medium text-gray-900"><%= Map.get(filter, :label, filter.module.label()) %></div>
               <.maybe_clear_button field={field} value={value} />
             </div>
             <div class="flex gap-4">


### PR DESCRIPTION
Add the possibility to configure filter label in filter map / definition:

```elixir
@impl Backpex.LiveResource
def filters do
  [
    category_id: %{
      module: MyAppWeb.Filters.Category,
      label: "Category"
    },
  ]
end
```

If no label is specified in the filter definition map, the label from the filter module is used. Therefore, this change is not breaking.