### PR TITLE
Fix truncate does not cut text in some fields

### DIFF
--- a/lib/backpex/fields/belongs_to.ex
+++ b/lib/backpex/fields/belongs_to.ex
@@ -72,7 +72,7 @@ defmodule Backpex.Fields.BelongsTo do
       |> assign_link()
 
     ~H"""
-    <div>
+    <div class={[@live_action in [:index, :resource_action] && "truncate"]}>
       <%= if @link do %>
         <.link navigate={@link} class={[@live_action in [:index, :resource_action] && "truncate", "hover:underline"]}>
           <%= @display_text %>

--- a/lib/backpex/fields/has_many.ex
+++ b/lib/backpex/fields/has_many.ex
@@ -179,7 +179,7 @@ defmodule Backpex.Fields.HasMany do
   @impl Backpex.Field
   def render_value(assigns) do
     ~H"""
-    <div>
+    <div class={[@live_action in [:index, :resource_action] && "truncate"]}>
       <%= if @value == [], do: raw("&mdash;") %>
 
       <div class={["flex", @live_action == :show && "flex-wrap"]}>
@@ -339,11 +339,11 @@ defmodule Backpex.Fields.HasMany do
 
     ~H"""
     <%= if is_nil(@link) do %>
-      <span class={@live_action in [:index, :resource_action] && "truncate"}>
+      <span>
         <%= HTML.pretty_value(@display_text) %>
       </span>
     <% else %>
-      <.link navigate={@link} class={["hover:underline", @live_action in [:index, :resource_action] && "truncate"]}>
+      <.link navigate={@link} class="hover:underline">
         <%= @display_text %>
       </.link>
     <% end %>

--- a/lib/backpex/fields/many_to_many.ex
+++ b/lib/backpex/fields/many_to_many.ex
@@ -179,7 +179,7 @@ defmodule Backpex.Fields.ManyToMany do
   @impl Backpex.Field
   def render_value(assigns) do
     ~H"""
-    <div>
+    <div class={[@live_action in [:index, :resource_action] && "truncate"]}>
       <%= if @value == [], do: raw("&mdash;") %>
 
       <div class={["flex", @live_action == :show && "flex-wrap"]}>
@@ -339,11 +339,11 @@ defmodule Backpex.Fields.ManyToMany do
 
     ~H"""
     <%= if is_nil(@link) do %>
-      <span class={@live_action in [:index, :resource_action] && "truncate"}>
+      <span>
         <%= HTML.pretty_value(@display_text) %>
       </span>
     <% else %>
-      <.link navigate={@link} class={["hover:underline", @live_action in [:index, :resource_action] && "truncate"]}>
+      <.link navigate={@link} class="hover:underline">
         <%= @display_text %>
       </.link>
     <% end %>

--- a/lib/backpex/fields/multi_select.ex
+++ b/lib/backpex/fields/multi_select.ex
@@ -102,7 +102,7 @@ defmodule Backpex.Fields.MultiSelect do
     assigns = assign(assigns, :selected_labels, selected_labels)
 
     ~H"""
-    <div>
+    <div class={[@live_action in [:index, :resource_action] && "truncate"]}>
       <%= if @selected_labels == [], do: raw("&mdash;") %>
 
       <div class={["flex", @live_action == :show && "flex-wrap"]}>


### PR DESCRIPTION
For some fields, the `truncate` class does not work properly in combination with `index_column_class` because the class is not applied to the root div of the live component.