### PR TITLE
Fix typo, :genral -> :general

### DIFF
--- a/lib/backpex.ex
+++ b/lib/backpex.ex
@@ -6,7 +6,7 @@ defmodule Backpex do
   @doc """
   Translates a string.
 
-  The type must be `:genral` or `:error`.
+  The type must be `:general` or `:error`.
   """
   def translate(msg, type \\ :general)
 


### PR DESCRIPTION
Found via `typos --hidden --format brief`