### PR TITLE
handle 404 for resource items

### DIFF
--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -841,7 +841,7 @@ defmodule Backpex.LiveResource do
         fields = filtered_fields_by_action(fields(), assigns, :edit)
 
         item =
-          Resource.get(
+          Resource.get!(
             assigns,
             &item_query(&1, live_action, assigns),
             fields,
@@ -870,7 +870,7 @@ defmodule Backpex.LiveResource do
         fields = filtered_fields_by_action(fields(), assigns, :show)
 
         item =
-          Resource.get(
+          Resource.get!(
             assigns,
             &item_query(&1, live_action, assigns),
             fields,
@@ -1444,7 +1444,7 @@ defmodule Backpex.LiveResource do
         %{assigns: %{live_action: live_action} = assigns} = socket
 
         fields = filtered_fields_by_action(fields(), assigns, :show)
-        item = Resource.get(assigns, &item_query(&1, live_action, assigns), fields, id)
+        item = Resource.get!(assigns, &item_query(&1, live_action, assigns), fields, id)
 
         socket =
           cond do

--- a/lib/backpex/resource.ex
+++ b/lib/backpex/resource.ex
@@ -256,7 +256,7 @@ defmodule Backpex.Resource do
   @doc """
   Gets a database record with the given fields by the given id, possibly being enhanced by the given item_query.
   """
-  def get(assigns, item_query, fields, id) do
+  def get!(assigns, item_query, fields, id) do
     %{
       repo: repo,
       schema: schema

--- a/lib/backpex/resource.ex
+++ b/lib/backpex/resource.ex
@@ -270,8 +270,15 @@ defmodule Backpex.Resource do
     |> maybe_join(associations)
     |> maybe_preload(associations, fields)
     |> maybe_merge_dynamic_fields(fields)
-    |> where([{^schema_name, schema_name}], schema_name.id == ^id)
+    |> where_id(schema_name, id)
     |> repo.one!()
+  end
+
+  defp where_id(query, schema_name, id) do
+    case Ecto.UUID.cast(id) do
+      {:ok, valid_id} -> where(query, [{^schema_name, schema_name}], schema_name.id == ^valid_id)
+      :error -> where(query, [{^schema_name, schema_name}], true == false)
+    end
   end
 
   @doc """

--- a/lib/backpex/resource.ex
+++ b/lib/backpex/resource.ex
@@ -271,7 +271,7 @@ defmodule Backpex.Resource do
     |> maybe_preload(associations, fields)
     |> maybe_merge_dynamic_fields(fields)
     |> where([{^schema_name, schema_name}], schema_name.id == ^id)
-    |> repo.one()
+    |> repo.one!()
   end
 
   @doc """


### PR DESCRIPTION
Resource show/edit fails when providing an incorrect `:id` in the path, because `Repo.get` just returns `nil` (for invalid UUIDs) or an cast error (for other invalid id strings).