### PR TITLE
Install deps during release step in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,12 @@ jobs:
           otp-version: ${{ steps.otp_version.outputs.version }}
           elixir-version: ${{ steps.elixir_version.outputs.version }}
 
+      - name: Install dependencies
+        run: |
+          mix local.hex --force --if-missing
+          mix local.rebar --force --if-missing
+          mix deps.get
+
       - name: Publish package on hex.pm
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}


### PR DESCRIPTION
The release step fails because of untracked dependencies: https://github.com/naymspace/backpex/actions/runs/9496374080/job/26170659459