### PR TITLE
Turn sentry meta tag into component

### DIFF
--- a/demo/lib/demo_web/components/core_components.ex
+++ b/demo/lib/demo_web/components/core_components.ex
@@ -4,8 +4,6 @@ defmodule DemoWeb.CoreComponents do
   """
   use Phoenix.Component
 
-  import Phoenix.HTML.Tag
-
   @doc """
   Renders the analytics snippet.
   """
@@ -26,11 +24,12 @@ defmodule DemoWeb.CoreComponents do
   @doc """
   Builds sentry meta tag.
   """
-  def sentry_meta_tag do
-    case Application.get_env(:sentry, :dsn) do
-      nil -> nil
-      dsn -> tag(:meta, name: "sentry-dsn", content: dsn)
-    end
+  def sentry_meta_tag(assigns) do
+    assigns = assign(assigns, :dsn, Application.get_env(:sentry, :dsn))
+
+    ~H"""
+    <meta :if={@dsn} name="sentry-dsn" content={@dsn} />
+    """
   end
 
   @doc """

--- a/demo/lib/demo_web/components/layouts/root.html.heex
+++ b/demo/lib/demo_web/components/layouts/root.html.heex
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <%= sentry_meta_tag() %>
+    <.sentry_meta_tag />
     <.live_title suffix=" · Backpex">
       <%= assigns[:page_title] || "Phoenix Admin Panel build with PETAL" %>
     </.live_title>


### PR DESCRIPTION
This PR removes `Phoenix.HTML.Tag` import in preparation for `phoenix_html` v4 upgrade.