### PR TITLE
change migrations to fix rollback in demo reset

### DIFF
--- a/demo/priv/repo/migrations/20221221111118_create_users.exs
+++ b/demo/priv/repo/migrations/20221221111118_create_users.exs
@@ -7,7 +7,7 @@ defmodule Demo.Repo.Migrations.CreateUsers do
       add(:first_name, :string, null: false)
       add(:last_name, :string, null: false)
       add(:role, :string, null: false)
-      add(:avatar, :string, null: false, default: "")
+      add(:avatar, :string, null: true, default: "")
 
       timestamps()
     end

--- a/demo/priv/repo/migrations/20221221111118_create_users.exs
+++ b/demo/priv/repo/migrations/20221221111118_create_users.exs
@@ -7,7 +7,7 @@ defmodule Demo.Repo.Migrations.CreateUsers do
       add(:first_name, :string, null: false)
       add(:last_name, :string, null: false)
       add(:role, :string, null: false)
-      add(:avatar, :string, null: true, default: "")
+      add(:avatar, :string, null: true)
 
       timestamps()
     end

--- a/demo/priv/repo/migrations/20240530093116_make_user_avatar_nullable.exs
+++ b/demo/priv/repo/migrations/20240530093116_make_user_avatar_nullable.exs
@@ -1,9 +1,0 @@
-defmodule Demo.Repo.Migrations.MakeUserAvatarNullable do
-  use Ecto.Migration
-
-  def change do
-    alter table(:users) do
-      modify(:avatar, :string, null: true)
-    end
-  end
-end


### PR DESCRIPTION
We are currently resetting the database via a full rollback of all migrations. This fails for `Demo.Repo.Migrations.MakeUserAvatarNullable`:

```
** (Ecto.MigrationError) cannot reverse migration command: alter table users. You will need to explicitly define up/0 and down/0 in your migration
    (ecto_sql 3.11.3) lib/ecto/migration/runner.ex:219: Ecto.Migration.Runner.execute_in_direction/5
    (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
    (ecto_sql 3.11.3) lib/ecto/migration/runner.ex:311: Ecto.Migration.Runner.perform_operation/3
    (stdlib 5.2.3) timer.erl:270: :timer.tc/2
    (ecto_sql 3.11.3) lib/ecto/migration/runner.ex:25: Ecto.Migration.Runner.run/8
    (ecto_sql 3.11.3) lib/ecto/migrator.ex:365: Ecto.Migrator.attempt/8
    (ecto_sql 3.11.3) lib/ecto/migrator.ex:325: anonymous fn/5 in Ecto.Migrator.do_down/5
```

I deleted the migration and changed the `:avatar` field in the original migration. Normally a no-go, but in the demo we can start with a fresh database for the next release and manually delete all data.