### PR TITLE
Prevent PETAL from being split at linebreaks

### DIFF
--- a/demo/lib/demo_web/live/home_live/index.html.heex
+++ b/demo/lib/demo_web/live/home_live/index.html.heex
@@ -11,12 +11,14 @@
       <h1 class="mt-10 text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">
         Phoenix Admin Panel built with
         <em class="text-primary-800 cursor-help leading-none tracking-wide">
-          <abbr
-            :for={tech <- ["Phoenix Framework", "Elixir", "Tailwind CSS", "Alpine.js", "LiveView"]}
-            title={tech}
-            class="text-primary inline-block no-underline transition hover:scale-110"
-            phx-no-format
-          ><%= String.at(tech, 0) %></abbr>
+          <nobr>
+            <abbr
+              :for={tech <- ["Phoenix Framework", "Elixir", "Tailwind CSS", "Alpine.js", "LiveView"]}
+              title={tech}
+              class="text-primary inline-block no-underline transition hover:scale-110"
+              phx-no-format
+            ><%= String.at(tech, 0) %></abbr>
+          </nobr>
         </em>
       </h1>
       <p class="mt-6 text-lg leading-8 text-gray-600">

--- a/demo/lib/demo_web/live/home_live/index.html.heex
+++ b/demo/lib/demo_web/live/home_live/index.html.heex
@@ -10,15 +10,13 @@
       </div>
       <h1 class="mt-10 text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">
         Phoenix Admin Panel built with
-        <em class="text-primary-800 cursor-help leading-none tracking-wide">
-          <nobr>
-            <abbr
-              :for={tech <- ["Phoenix Framework", "Elixir", "Tailwind CSS", "Alpine.js", "LiveView"]}
-              title={tech}
-              class="text-primary inline-block no-underline transition hover:scale-110"
-              phx-no-format
-            ><%= String.at(tech, 0) %></abbr>
-          </nobr>
+        <em class="text-primary-800 cursor-help whitespace-nowrap leading-none tracking-wide">
+          <abbr
+            :for={tech <- ["Phoenix Framework", "Elixir", "Tailwind CSS", "Alpine.js", "LiveView"]}
+            title={tech}
+            class="text-primary inline-block no-underline transition hover:scale-110"
+            phx-no-format
+          ><%= String.at(tech, 0) %></abbr>
         </em>
       </h1>
       <p class="mt-6 text-lg leading-8 text-gray-600">


### PR DESCRIPTION
Minor html improvement to remove linebreaks withing the PETAL acronym.