### PR TITLE
Pass persisted item to `consume_upload` function and pass `data` to item actions and resource actions

### DIFF
--- a/demo/lib/demo/product.ex
+++ b/demo/lib/demo/product.ex
@@ -25,7 +25,7 @@ defmodule Demo.Product do
   end
 
   @required_fields ~w[name quantity manufacturer price]a
-  @optional_fields ~w[images id]a
+  @optional_fields ~w[images]a
 
   def changeset(product, attrs, _metadata \\ []) do
     product

--- a/demo/lib/demo/product.ex
+++ b/demo/lib/demo/product.ex
@@ -25,7 +25,7 @@ defmodule Demo.Product do
   end
 
   @required_fields ~w[name quantity manufacturer price]a
-  @optional_fields ~w[images]a
+  @optional_fields ~w[images id]a
 
   def changeset(product, attrs, _metadata \\ []) do
     product

--- a/demo/lib/demo_web/item_actions/duplicate_tag.ex
+++ b/demo/lib/demo_web/item_actions/duplicate_tag.ex
@@ -49,7 +49,9 @@ defmodule DemoWeb.ItemActions.DuplicateTag do
   end
 
   @impl Backpex.ItemAction
-  def handle(socket, _items, params) do
+  def handle(socket, _items, data) do
+    params = Map.from_struct(data)
+
     result =
       %Demo.Tag{}
       |> Demo.Tag.create_changeset(params, target: nil, assigns: socket.assigns)

--- a/demo/lib/demo_web/item_actions/soft_delete.ex
+++ b/demo/lib/demo_web/item_actions/soft_delete.ex
@@ -55,7 +55,7 @@ defmodule DemoWeb.ItemActions.SoftDelete do
   end
 
   @impl Backpex.ItemAction
-  def handle(socket, items, _params) do
+  def handle(socket, items, _data) do
     datetime = DateTime.truncate(DateTime.utc_now(), :second)
 
     socket =

--- a/demo/lib/demo_web/live/product_live.ex
+++ b/demo/lib/demo_web/live/product_live.ex
@@ -117,7 +117,7 @@ defmodule DemoWeb.ProductLive do
   defp list_existing_files(%{images: images} = _item) when is_list(images), do: images
   defp list_existing_files(_item), do: []
 
-  defp put_upload_change(_socket, change, item, uploaded_entries, removed_entries, action) do
+  defp put_upload_change(_socket, params, item, uploaded_entries, removed_entries, action) do
     existing_files = list_existing_files(item) -- removed_entries
 
     new_entries =
@@ -131,11 +131,11 @@ defmodule DemoWeb.ProductLive do
 
     files = existing_files ++ Enum.map(new_entries, fn entry -> file_name(entry) end)
 
-    Map.put(change, "images", files)
+    Map.put(params, "images", files)
   end
 
   # sobelow_skip ["Traversal"]
-  defp consume_upload(_socket, _item, _change, %{path: path} = _meta, entry) do
+  defp consume_upload(_socket, _params, _item, %{path: path} = _meta, entry) do
     file_name = file_name(entry)
     dest = Path.join([:code.priv_dir(:demo), "static", upload_dir(), file_name])
 

--- a/demo/lib/demo_web/live/product_live.ex
+++ b/demo/lib/demo_web/live/product_live.ex
@@ -135,7 +135,7 @@ defmodule DemoWeb.ProductLive do
   end
 
   # sobelow_skip ["Traversal"]
-  defp consume_upload(_socket, item, %{path: path} = _meta, entry) do
+  defp consume_upload(_socket, _item, %{path: path} = _meta, entry) do
     file_name = file_name(entry)
     dest = Path.join([:code.priv_dir(:demo), "static", upload_dir(), file_name])
 

--- a/demo/lib/demo_web/live/product_live.ex
+++ b/demo/lib/demo_web/live/product_live.ex
@@ -36,7 +36,7 @@ defmodule DemoWeb.ProductLive do
         max_entries: 2,
         max_file_size: 512_000,
         put_upload_change: &put_upload_change/6,
-        consume_upload: &consume_upload/5,
+        consume_upload: &consume_upload/4,
         remove_uploads: &remove_uploads/3,
         list_existing_files: &list_existing_files/1,
         render: fn
@@ -135,7 +135,7 @@ defmodule DemoWeb.ProductLive do
   end
 
   # sobelow_skip ["Traversal"]
-  defp consume_upload(_socket, _params, _item, %{path: path} = _meta, entry) do
+  defp consume_upload(_socket, item, %{path: path} = _meta, entry) do
     file_name = file_name(entry)
     dest = Path.join([:code.priv_dir(:demo), "static", upload_dir(), file_name])
 

--- a/demo/lib/demo_web/live/product_live.ex
+++ b/demo/lib/demo_web/live/product_live.ex
@@ -36,7 +36,7 @@ defmodule DemoWeb.ProductLive do
         max_entries: 2,
         max_file_size: 512_000,
         put_upload_change: &put_upload_change/6,
-        consume_upload: &consume_upload/4,
+        consume_upload: &consume_upload/5,
         remove_uploads: &remove_uploads/3,
         list_existing_files: &list_existing_files/1,
         render: fn
@@ -135,7 +135,7 @@ defmodule DemoWeb.ProductLive do
   end
 
   # sobelow_skip ["Traversal"]
-  defp consume_upload(_socket, _item, %{path: path} = _meta, entry) do
+  defp consume_upload(_socket, _item, _change, %{path: path} = _meta, entry) do
     file_name = file_name(entry)
     dest = Path.join([:code.priv_dir(:demo), "static", upload_dir(), file_name])
 

--- a/demo/lib/demo_web/live/user_live.ex
+++ b/demo/lib/demo_web/live/user_live.ex
@@ -218,7 +218,7 @@ defmodule DemoWeb.UserLive do
   defp list_existing_files(%{avatar: avatar} = _item) when avatar != "" and not is_nil(avatar), do: [avatar]
   defp list_existing_files(_item), do: []
 
-  def put_upload_change(_socket, change, item, uploaded_entries, removed_entries, action) do
+  def put_upload_change(_socket, params, item, uploaded_entries, removed_entries, action) do
     existing_files = list_existing_files(item) -- removed_entries
 
     new_entries =
@@ -234,18 +234,18 @@ defmodule DemoWeb.UserLive do
 
     case files do
       [file] ->
-        Map.put(change, "avatar", file)
+        Map.put(params, "avatar", file)
 
       [_file | _other_files] ->
-        Map.put(change, "avatar", "too_many_files")
+        Map.put(params, "avatar", "too_many_files")
 
       [] ->
-        Map.put(change, "avatar", nil)
+        Map.put(params, "avatar", nil)
     end
   end
 
   # sobelow_skip ["Traversal"]
-  defp consume_upload(_socket, _item, _change, %{path: path} = _meta, entry) do
+  defp consume_upload(_socket, _params, _item, %{path: path} = _meta, entry) do
     file_name = file_name(entry)
     dest = Path.join([:code.priv_dir(:demo), "static", upload_dir(), file_name])
 

--- a/demo/lib/demo_web/live/user_live.ex
+++ b/demo/lib/demo_web/live/user_live.ex
@@ -58,7 +58,7 @@ defmodule DemoWeb.UserLive do
         max_entries: 1,
         max_file_size: 512_000,
         put_upload_change: &put_upload_change/6,
-        consume_upload: &consume_upload/5,
+        consume_upload: &consume_upload/4,
         remove_uploads: &remove_uploads/3,
         list_existing_files: &list_existing_files/1,
         render: fn
@@ -245,7 +245,7 @@ defmodule DemoWeb.UserLive do
   end
 
   # sobelow_skip ["Traversal"]
-  defp consume_upload(_socket, _params, _item, %{path: path} = _meta, entry) do
+  defp consume_upload(_socket, _item, %{path: path} = _meta, entry) do
     file_name = file_name(entry)
     dest = Path.join([:code.priv_dir(:demo), "static", upload_dir(), file_name])
 

--- a/demo/lib/demo_web/live/user_live.ex
+++ b/demo/lib/demo_web/live/user_live.ex
@@ -58,7 +58,7 @@ defmodule DemoWeb.UserLive do
         max_entries: 1,
         max_file_size: 512_000,
         put_upload_change: &put_upload_change/6,
-        consume_upload: &consume_upload/4,
+        consume_upload: &consume_upload/5,
         remove_uploads: &remove_uploads/3,
         list_existing_files: &list_existing_files/1,
         render: fn
@@ -245,7 +245,7 @@ defmodule DemoWeb.UserLive do
   end
 
   # sobelow_skip ["Traversal"]
-  defp consume_upload(_socket, _item, %{path: path} = _meta, entry) do
+  defp consume_upload(_socket, _item, _change, %{path: path} = _meta, entry) do
     file_name = file_name(entry)
     dest = Path.join([:code.priv_dir(:demo), "static", upload_dir(), file_name])
 

--- a/demo/lib/demo_web/resource_actions/email.ex
+++ b/demo/lib/demo_web/resource_actions/email.ex
@@ -37,7 +37,7 @@ defmodule DemoWeb.ResourceActions.Email do
   end
 
   @impl Backpex.ResourceAction
-  def handle(_socket, _params) do
+  def handle(_socket, _data) do
     # Send mail
 
     # We suppose there was no error.

--- a/demo/lib/demo_web/resource_actions/upload.ex
+++ b/demo/lib/demo_web/resource_actions/upload.ex
@@ -84,7 +84,7 @@ defmodule DemoWeb.ResourceActions.Upload do
     end
   end
 
-  defp consume_upload(_socket, _item, _change, _meta, entry) do
+  defp consume_upload(_socket, _params, _item, _meta, entry) do
     file_name = file_name(entry)
 
     # Copy file to destination

--- a/demo/lib/demo_web/resource_actions/upload.ex
+++ b/demo/lib/demo_web/resource_actions/upload.ex
@@ -54,7 +54,7 @@ defmodule DemoWeb.ResourceActions.Upload do
   end
 
   @impl Backpex.ResourceAction
-  def handle(_socket, _params), do: {:ok, "File was uploaded successfully."}
+  def handle(_socket, _data), do: {:ok, "File was uploaded successfully."}
 
   defp list_existing_files(_item), do: []
 

--- a/demo/lib/demo_web/resource_actions/upload.ex
+++ b/demo/lib/demo_web/resource_actions/upload.ex
@@ -20,7 +20,7 @@ defmodule DemoWeb.ResourceActions.Upload do
         accept: ~w(.jpg .jpeg .png),
         max_entries: 1,
         put_upload_change: &put_upload_change/6,
-        consume_upload: &consume_upload/5,
+        consume_upload: &consume_upload/4,
         remove_uploads: &remove_uploads/3,
         list_existing_files: &list_existing_files/1,
         type: :string
@@ -84,7 +84,7 @@ defmodule DemoWeb.ResourceActions.Upload do
     end
   end
 
-  defp consume_upload(_socket, _params, _item, _meta, entry) do
+  defp consume_upload(_socket, _item, _meta, entry) do
     file_name = file_name(entry)
 
     # Copy file to destination

--- a/demo/lib/demo_web/resource_actions/upload.ex
+++ b/demo/lib/demo_web/resource_actions/upload.ex
@@ -20,7 +20,7 @@ defmodule DemoWeb.ResourceActions.Upload do
         accept: ~w(.jpg .jpeg .png),
         max_entries: 1,
         put_upload_change: &put_upload_change/6,
-        consume_upload: &consume_upload/4,
+        consume_upload: &consume_upload/5,
         remove_uploads: &remove_uploads/3,
         list_existing_files: &list_existing_files/1,
         type: :string
@@ -84,7 +84,7 @@ defmodule DemoWeb.ResourceActions.Upload do
     end
   end
 
-  defp consume_upload(_socket, _item, _meta, entry) do
+  defp consume_upload(_socket, _item, _change, _meta, entry) do
     file_name = file_name(entry)
 
     # Copy file to destination

--- a/guides/actions/item-actions.md
+++ b/guides/actions/item-actions.md
@@ -56,7 +56,7 @@ defmodule DemoWeb.ItemAction.Show do
   def label(_assigns), do: Backpex.translate("Show")
 
   @impl Backpex.ItemAction
-  def handle(socket, [item | _items], _change) do
+  def handle(socket, [item | _items], _data) do
     path = Router.get_path(socket, socket.assigns.live_resource, socket.assigns.params, :show, item)
     {:noreply, Phoenix.LiveView.push_patch(socket, to: path)}
   end
@@ -158,7 +158,7 @@ defmodule DemoWeb.ItemAction.SoftDelete do
     def cancel_label(_assigns), do: Backpex.translate("Cancel")
 
     @impl Backpex.ItemAction
-    def handle(socket, items, params) do
+    def handle(socket, items, data) do
         datetime = DateTime.truncate(DateTime.utc_now(), :second)
 
         socket =
@@ -167,7 +167,7 @@ defmodule DemoWeb.ItemAction.SoftDelete do
                 Backpex.Resource.update_all(
                     socket.assigns,
                     items,
-                    [set: [deleted_at: datetime, reason: Map.get(params, "reason")]],
+                    [set: [deleted_at: datetime, reason: data.reason]],
                     "deleted"
                 )
 

--- a/guides/actions/resource-actions.md
+++ b/guides/actions/resource-actions.md
@@ -81,7 +81,7 @@ See `Backpex.ResourceAction` for a documentation of the callbacks.
 
 The [`handle/2`](Backpex.ResourceAction.html#c:handle/2) callback is called when the user submits the form to perform the action. In this example, we suppose there was no error sending the invitation email and return a success message.
 
-You can access the email entered by the user in the `data` argument. The `data` argument is a map that contains the casted and validated data from the form (received from [`Ecto.Changeset.apply_changes/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
+You can access the email entered by the user in the `data` argument. The `data` argument is a map that contains the casted and validated data from the form (received from [`Ecto.Changeset.apply_action/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
 
 We validate the email address using the `validate_email/2` function provided by the `Ecto.Changeset` module.
 

--- a/guides/actions/resource-actions.md
+++ b/guides/actions/resource-actions.md
@@ -64,14 +64,14 @@ defmodule MyAppWeb.Admin.Actions.Invite do
     end
 
     @impl Backpex.ResourceAction
-    def handle(_socket, params) do
+    def handle(_socket, data) do
         # Send mail
 
         # We suppose there was no error.
         if true do
-            {:ok, "An invitation email to #{params[:email]} was sent successfully."}
+            {:ok, "An invitation email to #{data.email} was sent successfully."}
         else
-            {:error, "An error occurred while sending an invitation email to  #{params[:email]}!"}
+            {:error, "An error occurred while sending an invitation email to  #{data.email}!"}
         end
     end
 end
@@ -81,7 +81,7 @@ See `Backpex.ResourceAction` for a documentation of the callbacks.
 
 The [`handle/2`](Backpex.ResourceAction.html#c:handle/2) callback is called when the user submits the form to perform the action. In this example, we suppose there was no error sending the invitation email and return a success message.
 
-You can access the email entered by the user in the `params` argument.
+You can access the email entered by the user in the `data` argument. The `data` argument is a map that contains the casted and validated data from the form (received from [`Ecto.Changeset.apply_changes/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
 
 We validate the email address using the `validate_email/2` function provided by the `Ecto.Changeset` module.
 

--- a/guides/upgrading/v0.3.md
+++ b/guides/upgrading/v0.3.md
@@ -41,7 +41,7 @@ We have updated `Backpex.Fields.Upload` and improved uploads in Backpex:
 
 For these requirements we have simplified the functions in `Backpex.FormComponent` and adapted the validation flow to classic Phoenix applications.
 
-We also updated the callback functions / options used for `Backpex.Fields.Upload`. Among other things, we have split `consume/2` into several callbacks (`put_upload_change/6` and `consume_upload/6`). This allows developers to put uploaded files to the change before consuming the uploads. This makes it possible to do validation on uploads (e.g. require files to be uploaded).
+We also updated the callback functions / options used for `Backpex.Fields.Upload`. Among other things, we have split `consume/2` into several callbacks (`put_upload_change/6` and `consume_upload/4`). This allows developers to put uploaded files to the change before consuming the uploads. This makes it possible to do validation on uploads (e.g. require files to be uploaded).
 
 We have also rewritten all the upload documentation in `Backpex.Fields.Upload`. It contains full examples for single and multiple upload fields.
 

--- a/guides/upgrading/v0.5.md
+++ b/guides/upgrading/v0.5.md
@@ -1,0 +1,39 @@
+# Upgrading to v0.5
+
+## Uploads: Change `consume_upload/4` to `consume_upload/5`
+
+With 0.5 we pass the change / params to the `consume_upload/5` function defined in `Backpex.Fields.Upload`. So if you have an upload field that looks like this
+
+```elixir
+def fields do
+    [
+        ...
+        images: %{
+            consume_upload: &consume_upload/4,
+        }
+
+    ]
+end
+
+defp consume_upload(_socket, _item, %{path: path} = _meta, entry) do
+    ...
+end
+```
+
+change it to the following by adding the `change` parameter to the `consume_upload` function
+
+```elixir
+def fields do
+    [
+        ...
+        images: %{
+            consume_upload: &consume_upload/5,
+        }
+
+    ]
+end
+
+defp consume_upload(_socket, _item, _change, %{path: path} = _meta, entry) do
+    ...
+end
+```

--- a/guides/upgrading/v0.5.md
+++ b/guides/upgrading/v0.5.md
@@ -16,9 +16,14 @@ defmodule MyAppWeb.Admin.ResourceActions.Invite do
 
     @impl Backpex.ResourceAction
     def handle(_socket, params) do
-        # do something with params
+        # Send invite mail to users
 
-        {:ok, "Success"}
+        # We suppose there was no error sending the mail.
+        if true do
+            {:ok, "An invitation email to #{params["email"]} was sent successfully."}
+        else
+            {:error, "An error occurred while sending an invitation email to  #{params["email"]}!"}
+        end
     end
 end
 ```
@@ -31,9 +36,14 @@ defmodule MyAppWeb.Admin.ResourceActions.Invite do
 
     @impl Backpex.ResourceAction
     def handle(_socket, data) do
-        # do something with data
+        # Send invite mail to users
 
-        {:ok, "Success"}
+        # We suppose there was no error sending the mail.
+        if true do
+            {:ok, "An invitation email to #{data.email} was sent successfully."}
+        else
+            {:error, "An error occurred while sending an invitation email to  #{data.email}!"}
+        end
     end
 end
 ```
@@ -52,7 +62,26 @@ defmodule MyAppWeb.Admin.ItemActions.Delete do
 
     @impl Backpex.ItemAction
     def handle(socket, items, params) do
-        # ...
+        datetime = DateTime.truncate(DateTime.utc_now(), :second)
+
+        socket =
+            try do
+                {:ok, _items} =
+                    Backpex.Resource.update_all(
+                        socket.assigns,
+                        items,
+                        [set: [deleted_at: datetime, reason: params["reason"]]],
+                        "deleted"
+                    )
+
+                socket
+                |> clear_flash()
+                |> put_flash(:info, "Item(s) successfully deleted.")
+            rescue
+                socket
+                |> clear_flash()
+                |> put_flash(:error, error)
+            end
 
         {:noreply, socket}
     end
@@ -67,7 +96,26 @@ defmodule MyAppWeb.Admin.ItemActions.Delete do
 
     @impl Backpex.ItemAction
     def handle(socket, items, data) do
-        # ...
+        datetime = DateTime.truncate(DateTime.utc_now(), :second)
+
+        socket =
+            try do
+                {:ok, _items} =
+                    Backpex.Resource.update_all(
+                        socket.assigns,
+                        items,
+                        [set: [deleted_at: datetime, reason: data.reason]],
+                        "deleted"
+                )
+
+                socket
+                |> clear_flash()
+                |> put_flash(:info, "Item(s) successfully deleted.")
+            rescue
+                socket
+                |> clear_flash()
+                |> put_flash(:error, error)
+            end
 
         {:noreply, socket}
     end

--- a/guides/upgrading/v0.5.md
+++ b/guides/upgrading/v0.5.md
@@ -3,3 +3,7 @@
 ## Uploads: Item in `consume_upload/4` now contains changes
 
 Previously, we passed the item without its changes to the `consume_upload/4` callback function. With 0.5, we now pass the persisted item (with its changes) to the function.
+
+## Resource actions now receives the data instead of the params
+
+Previously, resource actions received the params from the form. With 0.5, resource actions now receive the data from the form. The data is a map that contains the casted and validated data from the form (received from `Ecto.Changeset.apply_changes/2`).

--- a/guides/upgrading/v0.5.md
+++ b/guides/upgrading/v0.5.md
@@ -1,39 +1,5 @@
 # Upgrading to v0.5
 
-## Uploads: Change `consume_upload/4` to `consume_upload/5`
+## Uploads: Item in `consume_upload/4` now contains changes
 
-With 0.5 we pass the params to the `consume_upload/5` function defined in `Backpex.Fields.Upload`. So if you have an upload field that looks like this
-
-```elixir
-def fields do
-    [
-        ...
-        images: %{
-            consume_upload: &consume_upload/4,
-        }
-
-    ]
-end
-
-defp consume_upload(_socket, _item, %{path: path} = _meta, entry) do
-    ...
-end
-```
-
-change it to the following by adding the `params` parameter to the `consume_upload` function
-
-```elixir
-def fields do
-    [
-        ...
-        images: %{
-            consume_upload: &consume_upload/5,
-        }
-
-    ]
-end
-
-defp consume_upload(_socket, _params, _item, %{path: path} = _meta, entry) do
-    ...
-end
-```
+Previously, we passed the item without its changes to the `consume_upload/4` callback function. With 0.5, we now pass the persisted item (with its changes) to the function.

--- a/guides/upgrading/v0.5.md
+++ b/guides/upgrading/v0.5.md
@@ -2,7 +2,7 @@
 
 ## Uploads: Change `consume_upload/4` to `consume_upload/5`
 
-With 0.5 we pass the change / params to the `consume_upload/5` function defined in `Backpex.Fields.Upload`. So if you have an upload field that looks like this
+With 0.5 we pass the params to the `consume_upload/5` function defined in `Backpex.Fields.Upload`. So if you have an upload field that looks like this
 
 ```elixir
 def fields do
@@ -20,7 +20,7 @@ defp consume_upload(_socket, _item, %{path: path} = _meta, entry) do
 end
 ```
 
-change it to the following by adding the `change` parameter to the `consume_upload` function
+change it to the following by adding the `params` parameter to the `consume_upload` function
 
 ```elixir
 def fields do
@@ -33,7 +33,7 @@ def fields do
     ]
 end
 
-defp consume_upload(_socket, _item, _change, %{path: path} = _meta, entry) do
+defp consume_upload(_socket, _params, _item, %{path: path} = _meta, entry) do
     ...
 end
 ```

--- a/guides/upgrading/v0.5.md
+++ b/guides/upgrading/v0.5.md
@@ -4,6 +4,74 @@
 
 Previously, we passed the item without its changes to the `consume_upload/4` callback function. With 0.5, we now pass the persisted item (with its changes) to the function.
 
-## Resource actions now receives the data instead of the params
+## Resource Actions now receive the data instead of the params
 
-Previously, resource actions received the params from the form. With 0.5, resource actions now receive the data from the form. The data is a map that contains the casted and validated data from the form (received from `Ecto.Changeset.apply_changes/2`).
+Previously, Resource Actions received the params from the form. With 0.5, Resource Actions now receive the data from the form. The data is a map that contains the casted and validated data from the form (received from [`Ecto.Changeset.apply_changes/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
+
+If you had a resource action like this:
+
+```elixir
+defmodule MyAppWeb.Admin.ResourceActions.Invite do
+    # ...
+
+    @impl Backpex.ResourceAction
+    def handle(_socket, params) do
+        # do something with params
+
+        {:ok, "Success"}
+    end
+end
+```
+
+You should update it to:
+
+```elixir
+defmodule MyAppWeb.Admin.ResourceActions.Invite do
+    # ...
+
+    @impl Backpex.ResourceAction
+    def handle(_socket, data) do
+        # do something with data
+
+        {:ok, "Success"}
+    end
+end
+```
+
+Note that the data is now casted. Therefore you now have atom keys instead of string keys.
+
+## Item Actions now receive the data instead of the params
+
+Previously, Item Actions received the params from the form. With 0.5, Item Actions now receive the data from the form. The data is a map that contains the casted and validated data from the form (received from [`Ecto.Changeset.apply_changes/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
+
+If you had an item action like this:
+
+```elixir
+defmodule MyAppWeb.Admin.ItemActions.Delete do
+    # ...
+
+    @impl Backpex.ItemAction
+    def handle(socket, items, params) do
+        # ...
+
+        {:noreply, socket}
+    end
+end
+```
+
+You should update it to:
+
+```elixir
+defmodule MyAppWeb.Admin.ItemActions.Delete do
+    # ...
+
+    @impl Backpex.ItemAction
+    def handle(socket, items, data) do
+        # ...
+
+        {:noreply, socket}
+    end
+end
+```
+
+Note that the data is now casted. Therefore you now have atom keys instead of string keys.

--- a/guides/upgrading/v0.5.md
+++ b/guides/upgrading/v0.5.md
@@ -6,7 +6,7 @@ Previously, we passed the item without its changes to the `consume_upload/4` cal
 
 ## Resource Actions now receive the data instead of the params
 
-Previously, Resource Actions received the params from the form. With 0.5, Resource Actions now receive the data from the form. The data is a map that contains the casted and validated data from the form (received from [`Ecto.Changeset.apply_changes/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
+Previously, Resource Actions received the params from the form. With 0.5, Resource Actions now receive the data from the form. The data is a map that contains the casted and validated data from the form (received from [`Ecto.Changeset.apply_action/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
 
 If you had a resource action like this:
 
@@ -52,7 +52,7 @@ Note that the data is now casted. Therefore you now have atom keys instead of st
 
 ## Item Actions now receive the data instead of the params
 
-Previously, Item Actions received the params from the form. With 0.5, Item Actions now receive the data from the form. The data is a map that contains the casted and validated data from the form (received from [`Ecto.Changeset.apply_changes/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
+Previously, Item Actions received the params from the form. With 0.5, Item Actions now receive the data from the form. The data is a map that contains the casted and validated data from the form (received from [`Ecto.Changeset.apply_action/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
 
 If you had an item action like this:
 

--- a/lib/backpex/fields/upload.ex
+++ b/lib/backpex/fields/upload.ex
@@ -54,7 +54,6 @@ defmodule Backpex.Fields.Upload do
 
   **Parameters**
   * `:socket` - The socket.
-  * `:params` (map) - The current params that will be passed to the changeset function.
   * `:item` (struct) - The saved item (with its changes).
   * `:meta` - The upload meta.
   * `:entry` - The upload entry.

--- a/lib/backpex/fields/upload.ex
+++ b/lib/backpex/fields/upload.ex
@@ -55,7 +55,7 @@ defmodule Backpex.Fields.Upload do
   **Parameters**
   * `:socket` - The socket.
   * `:params` (map) - The current params that will be passed to the changeset function.
-  * `:item` (struct) - The item without its changes.
+  * `:item` (struct) - The saved item (with its changes).
   * `:meta` - The upload meta.
   * `:entry` - The upload entry.
 
@@ -63,7 +63,7 @@ defmodule Backpex.Fields.Upload do
 
   **Example**
 
-      defp consume_upload(_socket, _params, _item, %{path: path} = _meta, entry) do
+      defp consume_upload(_socket, _item, %{path: path} = _meta, entry) do
         file_name = ...
         file_url = ...
         static_dir = ...
@@ -175,7 +175,7 @@ defmodule Backpex.Fields.Upload do
               max_entries: 1,
               max_file_size: 512_000,
               put_upload_change: &put_upload_change/6,
-              consume_upload: &consume_upload/5,
+              consume_upload: &consume_upload/4,
               remove_uploads: &remove_uploads/3,
               list_existing_files: &list_existing_files/1,
               render: fn
@@ -219,7 +219,7 @@ defmodule Backpex.Fields.Upload do
           end
         end
 
-        defp consume_upload(_socket, _params, _item, %{path: path} = _meta, entry) do
+        defp consume_upload(_socket, _item, %{path: path} = _meta, entry) do
           file_name = file_name(entry)
           dest = Path.join([:code.priv_dir(:demo), "static", upload_dir(), file_name])
 
@@ -292,7 +292,7 @@ defmodule Backpex.Fields.Upload do
               max_entries: 2,
               max_file_size: 512_000,
               put_upload_change: &put_upload_change/6,
-              consume_upload: &consume_upload/5,
+              consume_upload: &consume_upload/4,
               remove_uploads: &remove_uploads/3,
               list_existing_files: &list_existing_files/1,
               render: fn
@@ -333,7 +333,7 @@ defmodule Backpex.Fields.Upload do
           Map.put(params, "images", files)
         end
 
-        defp consume_upload(_socket, _params, _item, %{path: path} = _meta, entry) do
+        defp consume_upload(_socket, _item, %{path: path} = _meta, entry) do
           file_name = file_name(entry)
           dest = Path.join([:code.priv_dir(:demo), "static", upload_dir(), file_name])
 

--- a/lib/backpex/fields/upload.ex
+++ b/lib/backpex/fields/upload.ex
@@ -55,6 +55,7 @@ defmodule Backpex.Fields.Upload do
   **Parameters**
   * `:socket` - The socket.
   * `:item` (struct) - The item without its changes.
+  * `:change` (map) - The current change / attrs that will be passed to the changeset function.
   * `:meta` - The upload meta.
   * `:entry` - The upload entry.
 
@@ -62,7 +63,7 @@ defmodule Backpex.Fields.Upload do
 
   **Example**
 
-      defp consume_upload(_socket, _item, %{path: path} = _meta, entry) do
+      defp consume_upload(_socket, _item, _change, %{path: path} = _meta, entry) do
         file_name = ...
         file_url = ...
         static_dir = ...
@@ -174,7 +175,7 @@ defmodule Backpex.Fields.Upload do
               max_entries: 1,
               max_file_size: 512_000,
               put_upload_change: &put_upload_change/6,
-              consume_upload: &consume_upload/4,
+              consume_upload: &consume_upload/5,
               remove_uploads: &remove_uploads/3,
               list_existing_files: &list_existing_files/1,
               render: fn
@@ -218,7 +219,7 @@ defmodule Backpex.Fields.Upload do
           end
         end
 
-        defp consume_upload(_socket, _item, %{path: path} = _meta, entry) do
+        defp consume_upload(_socket, _item, _change, %{path: path} = _meta, entry) do
           file_name = file_name(entry)
           dest = Path.join([:code.priv_dir(:demo), "static", upload_dir(), file_name])
 
@@ -291,7 +292,7 @@ defmodule Backpex.Fields.Upload do
               max_entries: 2,
               max_file_size: 512_000,
               put_upload_change: &put_upload_change/6,
-              consume_upload: &consume_upload/4,
+              consume_upload: &consume_upload/5,
               remove_uploads: &remove_uploads/3,
               list_existing_files: &list_existing_files/1,
               render: fn
@@ -332,7 +333,7 @@ defmodule Backpex.Fields.Upload do
           Map.put(change, "images", files)
         end
 
-        defp consume_upload(_socket, _item, %{path: path} = _meta, entry) do
+        defp consume_upload(_socket, _item, _change, %{path: path} = _meta, entry) do
           file_name = file_name(entry)
           dest = Path.join([:code.priv_dir(:demo), "static", upload_dir(), file_name])
 

--- a/lib/backpex/fields/upload.ex
+++ b/lib/backpex/fields/upload.ex
@@ -15,7 +15,7 @@ defmodule Backpex.Fields.Upload do
     * `:list_existing_files` (function) - Required function that returns a list of all uploaded files based on an item.
     * `:file_label` (function) - Optional function to get the label of a single file.
     * `:consume_upload` (function) - Required function to consume file uploads.
-    * `:put_upload_change` (function) - Required function to add file paths to the change.
+    * `:put_upload_change` (function) - Required function to add file paths to the params.
     * `:remove_uploads` (function) - Required function that is being called after saving an item to be able to delete removed files
 
 
@@ -54,8 +54,8 @@ defmodule Backpex.Fields.Upload do
 
   **Parameters**
   * `:socket` - The socket.
+  * `:params` (map) - The current params that will be passed to the changeset function.
   * `:item` (struct) - The item without its changes.
-  * `:change` (map) - The current change / attrs that will be passed to the changeset function.
   * `:meta` - The upload meta.
   * `:entry` - The upload entry.
 
@@ -63,7 +63,7 @@ defmodule Backpex.Fields.Upload do
 
   **Example**
 
-      defp consume_upload(_socket, _item, _change, %{path: path} = _meta, entry) do
+      defp consume_upload(_socket, _params, _item, %{path: path} = _meta, entry) do
         file_name = ...
         file_url = ...
         static_dir = ...
@@ -78,17 +78,17 @@ defmodule Backpex.Fields.Upload do
 
   **Parameters**
     * `:socket` - The socket.
-    * `:change` (map) - The current change / attrs that will be passed to the changeset function.
+    * `:params` (map) - The current params that will be passed to the changeset function.
     * `:item` (struct) - The item without its changes. On create will this will be an empty map.
     * `uploaded_entries` (tuple) - The completed and in progress entries for the upload.
     * `removed_entries` (list) - A list of removed uploads during edit.
     * `action` (atom) - The action (`:validate` or `:insert`)
 
-  This function is used to modify the change based on certain parameters. It is important because it ensures that file paths are added to the item change and therefore persisted in the database. This option is required.
+  This function is used to modify the params based on certain parameters. It is important because it ensures that file paths are added to the item change and therefore persisted in the database. This option is required.
 
   **Example**
 
-      def put_upload_change(_socket, change, item, uploaded_entries, removed_entries, action) do
+      def put_upload_change(_socket, params, item, uploaded_entries, removed_entries, action) do
         existing_files = item.files -- removed_entries
 
         new_entries =
@@ -102,7 +102,7 @@ defmodule Backpex.Fields.Upload do
 
         files = existing_files ++ Enum.map(new_entries, fn entry -> file_name(entry) end)
 
-        Map.put(change, "images", files)
+        Map.put(params, "images", files)
       end
 
   ### `remove_uploads`
@@ -193,7 +193,7 @@ defmodule Backpex.Fields.Upload do
         defp list_existing_files(%{avatar: avatar} = _item) when avatar != "" and not is_nil(avatar), do: [avatar]
         defp list_existing_files(_item), do: []
 
-        def put_upload_change(_socket, change, item, uploaded_entries, removed_entries, action) do
+        def put_upload_change(_socket, params, item, uploaded_entries, removed_entries, action) do
           existing_files = list_existing_files(item) -- removed_entries
 
           new_entries =
@@ -209,17 +209,17 @@ defmodule Backpex.Fields.Upload do
 
           case files do
             [file] ->
-              Map.put(change, "avatar", file)
+              Map.put(params, "avatar", file)
 
             [_file | _other_files] ->
-              Map.put(change, "avatar", "too_many_files")
+              Map.put(params, "avatar", "too_many_files")
 
             [] ->
-              Map.put(change, "avatar", "")
+              Map.put(params, "avatar", "")
           end
         end
 
-        defp consume_upload(_socket, _item, _change, %{path: path} = _meta, entry) do
+        defp consume_upload(_socket, _params, _item, %{path: path} = _meta, entry) do
           file_name = file_name(entry)
           dest = Path.join([:code.priv_dir(:demo), "static", upload_dir(), file_name])
 
@@ -316,7 +316,7 @@ defmodule Backpex.Fields.Upload do
         defp list_existing_files(%{images: images} = _item) when is_list(images), do: images
         defp list_existing_files(_item), do: []
 
-        defp put_upload_change(_socket, change, item, uploaded_entries, removed_entries, action) do
+        defp put_upload_change(_socket, params, item, uploaded_entries, removed_entries, action) do
           existing_files = list_existing_files(item) -- removed_entries
 
           new_entries =
@@ -330,10 +330,10 @@ defmodule Backpex.Fields.Upload do
 
           files = existing_files ++ Enum.map(new_entries, fn entry -> file_name(entry) end)
 
-          Map.put(change, "images", files)
+          Map.put(params, "images", files)
         end
 
-        defp consume_upload(_socket, _item, _change, %{path: path} = _meta, entry) do
+        defp consume_upload(_socket, _params, _item, %{path: path} = _meta, entry) do
           file_name = file_name(entry)
           dest = Path.join([:code.priv_dir(:demo), "static", upload_dir(), file_name])
 

--- a/lib/backpex/item_actions/delete.ex
+++ b/lib/backpex/item_actions/delete.ex
@@ -36,7 +36,7 @@ defmodule Backpex.ItemActions.Delete do
   def cancel_label(_assigns), do: Backpex.translate("Cancel")
 
   @impl Backpex.ItemAction
-  def handle(socket, items, _params) do
+  def handle(socket, items, _data) do
     socket =
       try do
         %{assigns: %{repo: repo, schema: schema, pubsub: pubsub}} = socket

--- a/lib/backpex/item_actions/edit.ex
+++ b/lib/backpex/item_actions/edit.ex
@@ -16,7 +16,7 @@ defmodule Backpex.ItemActions.Edit do
   def label(_assigns), do: Backpex.translate("Edit")
 
   @impl Backpex.ItemAction
-  def handle(socket, [item | _items], _change) do
+  def handle(socket, [item | _items], _data) do
     path = Router.get_path(socket, socket.assigns.live_resource, socket.assigns.params, :edit, item)
 
     {:noreply, Phoenix.LiveView.push_patch(socket, to: path)}

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -73,7 +73,7 @@ defmodule Backpex.ItemAction do
   @callback confirm(assigns :: map()) :: binary()
 
   @doc """
-  Performs the action. It takes the socket and the casted and validated data (received from [`Ecto.Changeset.apply_changes/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
+  Performs the action. It takes the socket and the casted and validated data (received from [`Ecto.Changeset.apply_action/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
   """
   @callback handle(socket :: Phoenix.LiveView.Socket.t(), items :: list(map()), params :: map() | struct()) ::
               {:noreply, Phoenix.LiveView.Socket.t()} | {:reply, map(), Phoenix.LiveView.Socket.t()}

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -73,9 +73,9 @@ defmodule Backpex.ItemAction do
   @callback confirm(assigns :: map()) :: binary()
 
   @doc """
-  Performs the action.
+  Performs the action. It takes the socket and the casted and validated data (received from [`Ecto.Changeset.apply_changes/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
   """
-  @callback handle(socket :: Phoenix.LiveView.Socket.t(), items :: list(map()), params :: map()) ::
+  @callback handle(socket :: Phoenix.LiveView.Socket.t(), items :: list(map()), params :: map() | struct()) ::
               {:noreply, Phoenix.LiveView.Socket.t()} | {:reply, map(), Phoenix.LiveView.Socket.t()}
 
   @optional_callbacks confirm: 1, confirm_label: 1, cancel_label: 1, changeset: 3, fields: 0

--- a/lib/backpex/item_actions/show.ex
+++ b/lib/backpex/item_actions/show.ex
@@ -16,7 +16,7 @@ defmodule Backpex.ItemActions.Show do
   def label(_assigns), do: Backpex.translate("Show")
 
   @impl Backpex.ItemAction
-  def handle(socket, [item | _items], _change) do
+  def handle(socket, [item | _items], _data) do
     path = Router.get_path(socket, socket.assigns.live_resource, socket.assigns.params, :show, item)
     {:noreply, Phoenix.LiveView.push_patch(socket, to: path)}
   end

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -329,9 +329,9 @@ defmodule Backpex.FormComponent do
 
     case result do
       {:ok, data} ->
-        result = resource_action.module.handle(socket, data)
+        resource_action_result = resource_action.module.handle(socket, data)
 
-        if match?({:ok, _msg}, result), do: handle_uploads(socket, data)
+        if match?({:ok, _msg}, resource_action_result), do: handle_uploads(socket, data)
 
         socket =
           socket

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -223,7 +223,7 @@ defmodule Backpex.FormComponent do
       pubsub: assigns[:pubsub],
       assocs: Map.get(assigns, :assocs, []),
       after_save: fn item ->
-        handle_uploads(socket)
+        handle_uploads(socket, params)
         live_resource.on_item_created(socket, item)
 
         {:ok, item}
@@ -275,7 +275,7 @@ defmodule Backpex.FormComponent do
       pubsub: assigns[:pubsub],
       assocs: Map.get(assigns, :assocs, []),
       after_save: fn item ->
-        handle_uploads(socket)
+        handle_uploads(socket, params)
         live_resource.on_item_updated(socket, item)
 
         {:ok, item}
@@ -328,7 +328,7 @@ defmodule Backpex.FormComponent do
       %{valid?: true} ->
         result = resource_action.module.handle(socket, params)
 
-        if match?({:ok, _msg}, result), do: handle_uploads(socket)
+        if match?({:ok, _msg}, result), do: handle_uploads(socket, params)
 
         socket =
           socket
@@ -427,7 +427,7 @@ defmodule Backpex.FormComponent do
     end)
   end
 
-  defp handle_uploads(%{assigns: %{uploads: _uploads}} = socket) do
+  defp handle_uploads(%{assigns: %{uploads: _uploads}} = socket, params) do
     for {_name, %{upload_key: upload_key} = field_options} = _field <- socket.assigns.fields do
       if Map.has_key?(socket.assigns.uploads, upload_key) do
         %{consume_upload: consume_upload, remove_uploads: remove_uploads} = field_options
@@ -435,7 +435,7 @@ defmodule Backpex.FormComponent do
         item = socket.assigns.item
 
         consume_uploaded_entries(socket, upload_key, fn meta, entry ->
-          consume_upload.(socket, item, meta, entry)
+          consume_upload.(socket, item, params, meta, entry)
         end)
 
         removed_entries = Keyword.get(socket.assigns.removed_uploads, upload_key, [])
@@ -444,7 +444,7 @@ defmodule Backpex.FormComponent do
     end
   end
 
-  defp handle_uploads(_socket), do: :ok
+  defp handle_uploads(_socket, _params), do: :ok
 
   def render(assigns) do
     form_component(assigns)

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -336,7 +336,7 @@ defmodule Backpex.FormComponent do
         socket =
           socket
           |> assign(:show_form_errors, false)
-          |> put_flash_message(result)
+          |> put_flash_message(resource_action_result)
           |> push_navigate(to: return_to)
 
         {:noreply, socket}

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -223,7 +223,7 @@ defmodule Backpex.FormComponent do
       pubsub: assigns[:pubsub],
       assocs: Map.get(assigns, :assocs, []),
       after_save: fn item ->
-        handle_uploads(socket, params)
+        handle_uploads(socket, item)
         live_resource.on_item_created(socket, item)
 
         {:ok, item}
@@ -275,7 +275,7 @@ defmodule Backpex.FormComponent do
       pubsub: assigns[:pubsub],
       assocs: Map.get(assigns, :assocs, []),
       after_save: fn item ->
-        handle_uploads(socket, params)
+        handle_uploads(socket, item)
         live_resource.on_item_updated(socket, item)
 
         {:ok, item}
@@ -427,15 +427,13 @@ defmodule Backpex.FormComponent do
     end)
   end
 
-  defp handle_uploads(%{assigns: %{uploads: _uploads}} = socket, params) do
+  defp handle_uploads(%{assigns: %{uploads: _uploads}} = socket, item) do
     for {_name, %{upload_key: upload_key} = field_options} = _field <- socket.assigns.fields do
       if Map.has_key?(socket.assigns.uploads, upload_key) do
         %{consume_upload: consume_upload, remove_uploads: remove_uploads} = field_options
 
-        item = socket.assigns.item
-
         consume_uploaded_entries(socket, upload_key, fn meta, entry ->
-          consume_upload.(socket, params, item, meta, entry)
+          consume_upload.(socket, item, meta, entry)
         end)
 
         removed_entries = Keyword.get(socket.assigns.removed_uploads, upload_key, [])
@@ -444,7 +442,7 @@ defmodule Backpex.FormComponent do
     end
   end
 
-  defp handle_uploads(_socket, _params), do: :ok
+  defp handle_uploads(_socket, _item), do: :ok
 
   def render(assigns) do
     form_component(assigns)

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -435,7 +435,7 @@ defmodule Backpex.FormComponent do
         item = socket.assigns.item
 
         consume_uploaded_entries(socket, upload_key, fn meta, entry ->
-          consume_upload.(socket, item, params, meta, entry)
+          consume_upload.(socket, params, item, meta, entry)
         end)
 
         removed_entries = Keyword.get(socket.assigns.removed_uploads, upload_key, [])

--- a/lib/backpex/resource_action.ex
+++ b/lib/backpex/resource_action.ex
@@ -54,7 +54,7 @@ defmodule Backpex.ResourceAction do
             ) :: Ecto.Changeset.t()
 
   @doc """
-  The handle function for the corresponding action. It receives the socket and casted and validated data (received from [`Ecto.Changeset.apply_changes/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)) and will be called when the form is valid and submitted.
+  The handle function for the corresponding action. It receives the socket and casted and validated data (received from [`Ecto.Changeset.apply_action/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)) and will be called when the form is valid and submitted.
 
   It must return either `{:ok, binary()}` or `{:error, binary()}`
   """

--- a/lib/backpex/resource_action.ex
+++ b/lib/backpex/resource_action.ex
@@ -54,11 +54,11 @@ defmodule Backpex.ResourceAction do
             ) :: Ecto.Changeset.t()
 
   @doc """
-  The handle function for the corresponding action. It receives the params and will be called when the form is valid and submitted.
+  The handle function for the corresponding action. It receives the data (received from [`Ecto.Changeset.apply_changes/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)) and will be called when the form is valid and submitted.
 
   It must return either `{:ok, binary()}` or `{:error, binary()}`
   """
-  @callback handle(socket :: Phoenix.LiveView.Socket.t(), params :: map()) ::
+  @callback handle(socket :: Phoenix.LiveView.Socket.t(), data :: map()) ::
               {:ok, binary()} | {:error, binary()}
 
   @doc """

--- a/lib/backpex/resource_action.ex
+++ b/lib/backpex/resource_action.ex
@@ -54,7 +54,7 @@ defmodule Backpex.ResourceAction do
             ) :: Ecto.Changeset.t()
 
   @doc """
-  The handle function for the corresponding action. It receives the data (received from [`Ecto.Changeset.apply_changes/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)) and will be called when the form is valid and submitted.
+  The handle function for the corresponding action. It receives the socket and casted and validated data (received from [`Ecto.Changeset.apply_changes/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)) and will be called when the form is valid and submitted.
 
   It must return either `{:ok, binary()}` or `{:error, binary()}`
   """

--- a/mix.exs
+++ b/mix.exs
@@ -145,6 +145,7 @@ defmodule Backpex.MixProject do
       "guides/translations/translations.md",
 
       # Upgrade Guides
+      "guides/upgrading/v0.5.md",
       "guides/upgrading/v0.3.md",
       "guides/upgrading/v0.2.md"
     ]


### PR DESCRIPTION
- Pass persisted item with its changes to `consume_upload/4`.
- Pass `data` from `Ecto.Changeset.apply_changes/2`  instead of `params` to item action's `handle` function
- Pass `data` from `Ecto.Changeset.apply_changes/2`  instead of `params` to resource action's `handle` function