### PR TITLE
Display newlines and whitespaces for textarea values

### DIFF
--- a/lib/backpex/fields/textarea.ex
+++ b/lib/backpex/fields/textarea.ex
@@ -13,9 +13,13 @@ defmodule Backpex.Fields.Textarea do
   @impl Backpex.Field
   def render_value(assigns) do
     ~H"""
-    <p class={@live_action in [:index, :resource_action] && "truncate"}>
-      <%= HTML.pretty_value(@value) %>
-    </p>
+    <p
+      class={[
+        @live_action in [:index, :resource_action] && "truncate",
+        @live_action == :show && "overflow-x-auto whitespace-pre-wrap"
+      ]}
+      phx-no-format
+    ><%= HTML.pretty_value(@value) %></p>
     """
   end
 


### PR DESCRIPTION
Previously, newlines and spaces were collapsed in textarea values on show views. With this PR, textarea values are now displayed as in the input (show view only).

![image](https://github.com/naymspace/backpex/assets/60519307/c323b3af-b942-4c65-81f4-dc8909bf0a71)
