### PR TITLE
Fix `update_item` may cause errors

### DIFF
--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -911,16 +911,16 @@ defmodule Backpex.LiveResource do
         %{assigns: %{live_action: live_action, repo: repo, schema: schema} = assigns} = socket
 
         fields = filtered_fields_by_action(fields(), assigns, :show)
-        item = Resource.get!(id, repo, schema, &item_query(&1, live_action, assigns), fields)
+        item = Resource.get(id, repo, schema, &item_query(&1, live_action, assigns), fields)
 
         socket =
           cond do
-            live_action in [:index, :resource_action] ->
+            live_action in [:index, :resource_action] and item ->
               items = Enum.map(socket.assigns.items, &if(&1.id == id, do: item, else: &1))
 
               assign(socket, :items, items)
 
-            live_action == :show ->
+            live_action == :show and item ->
               assign(socket, :item, item)
 
             true ->

--- a/lib/backpex/resource.ex
+++ b/lib/backpex/resource.ex
@@ -254,7 +254,7 @@ defmodule Backpex.Resource do
   end
 
   @doc """
-  Gets a database record with the given fields by the given id.
+  Gets a database record with the given fields by the given id. Raises Ecto.NoResultsError if no record was found.
 
   ## Parameters
 
@@ -265,6 +265,25 @@ defmodule Backpex.Resource do
   * `fields` (list): A list of atoms representing the fields to be selected and potentially preloaded.
   """
   def get!(id, repo, schema, item_query, fields) do
+    query_record(id, repo, schema, item_query, fields, :one!)
+  end
+
+  @doc """
+  Gets a database record with the given fields by the given id. Returns nil if no result was found.
+
+  ## Parameters
+
+  * `id`: The identifier for the specific item to be fetched.
+  * `repo` (module): The repository module.
+  * `schema`: The Ecto schema module corresponding to the item
+  * `item_query` (function): A function that modifies the base query. This function should accept an Ecto.Queryable and return an Ecto.Queryable. It's used to apply additional query logic.
+  * `fields` (list): A list of atoms representing the fields to be selected and potentially preloaded.
+  """
+  def get(id, repo, schema, item_query, fields) do
+    query_record(id, repo, schema, item_query, fields, :one)
+  end
+
+  defp query_record(id, repo, schema, item_query, fields, fetch_function) do
     schema_name = name_by_schema(schema)
     id_type = schema.__schema__(:type, :id)
     associations = associations(fields, schema)
@@ -275,7 +294,7 @@ defmodule Backpex.Resource do
     |> maybe_preload(associations, fields)
     |> maybe_merge_dynamic_fields(fields)
     |> where_id(schema_name, id_type, id)
-    |> repo.one!()
+    |> then(fn query -> apply(repo, fetch_function, [query]) end)
   end
 
   defp where_id(query, schema_name, :id, id) do


### PR DESCRIPTION
It's possible that `update_item` raises an `Ecto.NoResultsError`. For example, if the `item_query` adds additional filters (e.g., limit access to specific users). We would rather not raise in this case.

