### PR TITLE
Fix toggle column width

### DIFF
--- a/lib/backpex/html/resource.ex
+++ b/lib/backpex/html/resource.ex
@@ -340,8 +340,8 @@ defmodule Backpex.HTML.Resource do
           class="h-5 w-5 text-base-content/50 hover:text-base-content"
         />
       </label>
-      <div tabindex="0" class="dropdown-content z-[1] menu bg-base-100 rounded-box w-52 p-4 shadow">
-        <.form method="POST" for={@form} action={cookie_path(@socket)}>
+      <div tabindex="0" class="dropdown-content z-[1] menu bg-base-100 rounded-box min-w-52 max-w-72 p-4 shadow">
+        <.form class="w-full" method="POST" for={@form} action={cookie_path(@socket)}>
           <input type="hidden" name={@form[:_resource].name} value={@form[:_resource].value} />
           <input type="hidden" name={@form[:_cookie_redirect_url].name} value={@form[:_cookie_redirect_url].value} />
           <.toggle_columns_inputs active_fields={@active_fields} form={@form} />
@@ -364,7 +364,7 @@ defmodule Backpex.HTML.Resource do
         <label class="flex cursor-pointer items-center">
           <input type="hidden" name={@form[name].name} value="false" />
           <input type="checkbox" name={@form[name].name} class="checkbox checkbox-sm checkbox-primary" checked={active} />
-          <span class="label-text pl-2">
+          <span class="label-text truncate pl-2">
             <%= label %>
           </span>
         </label>


### PR DESCRIPTION
Set a min and a max width for the toggle column dropdown truncating text that overflows, closes #166 .

![Screenshot_20240716_010133](https://github.com/user-attachments/assets/8b2f2f6f-71da-4476-8f95-beb0e0608690)
![long](https://github.com/user-attachments/assets/bd7f52ed-4ac2-4d87-a5aa-c11a400e1399)
