### PR TITLE
Fix `Backpex.Resource.update_all/6` when used without pubsub arg

### DIFF
--- a/lib/backpex/resource.ex
+++ b/lib/backpex/resource.ex
@@ -503,9 +503,7 @@ defmodule Backpex.Resource do
     {:ok, item}
   end
 
-  defp broadcast({:ok, item} = event, _event, nil) do: event
-
-  defp broadcast({:error, _reason} = event, _event, _pubsub), do: event
+  defp broadcast(result, _event, _pubsub), do: result
 
   defp event_name(event_prefix, event), do: event_prefix <> event
 

--- a/lib/backpex/resource.ex
+++ b/lib/backpex/resource.ex
@@ -503,6 +503,8 @@ defmodule Backpex.Resource do
     {:ok, item}
   end
 
+  defp broadcast({:ok, item} = event, _event, nil) do: event
+
   defp broadcast({:error, _reason} = event, _event, _pubsub), do: event
 
   defp event_name(event_prefix, event), do: event_prefix <> event


### PR DESCRIPTION
Before this change when someone called the function with 5 arguments `FunctionClauseError` was risen.