### PR TITLE
Update installation.md

### DIFF
--- a/guides/get_started/installation.md
+++ b/guides/get_started/installation.md
@@ -172,16 +172,17 @@ defmodule MyAppWeb.Live.PostLive do
 
   @impl Backpex.LiveResource
   def fields do
-  [
-    title: %{
-      module: Backpex.Fields.Text,
-      label: "Title"
-    },
-    views: %{
-      module: Backpex.Fields.Number,
-      label: "Views"
-    }
-  ]
+    [
+      title: %{
+        module: Backpex.Fields.Text,
+        label: "Title"
+      },
+      views: %{
+        module: Backpex.Fields.Number,
+        label: "Views"
+      }
+    ]
+  end
 end
 ```
 


### PR DESCRIPTION
There was a missing `end` delimiter in the example which might be hard to spot for new users.