### PR TITLE
Check for named binding before joining

### DIFF
--- a/lib/backpex/resource.ex
+++ b/lib/backpex/resource.ex
@@ -106,11 +106,15 @@ defmodule Backpex.Resource do
       %{queryable: queryable, owner_key: owner_key, cardinality: :one} = association, query ->
         custom_alias = Map.get(association, :custom_alias, name_by_schema(queryable))
 
-        from(item in query,
-          left_join: b in ^queryable,
-          as: ^custom_alias,
-          on: field(item, ^owner_key) == b.id
-        )
+        if has_named_binding?(query, custom_alias) do
+          query
+        else
+          from(item in query,
+            left_join: b in ^queryable,
+            as: ^custom_alias,
+            on: field(item, ^owner_key) == b.id
+          )
+        end
 
       _relation, query ->
         query


### PR DESCRIPTION
closes #530 

This PR checks for a named binding before joining. It prevents an error being thrown if a join with the same alias has already been performed, e.g. in the `item_query` function.

However, if we do not explicitly set an alias when joining in `item_query` this will **not** prevent a second join from being performed.

Consider a post belonging to a user. If we define an item query like this.

```elixir
@impl Backpex.LiveResource
def item_query(query, live_action, assigns) do
  query
  |> join(:left, [p], u in Demo.User, on: u.id == p.user_id)
end
```

`maybe_join` will do a second join because there is no alias `user` → `has_named_binding/2` returns false.

If we want to prevent a second join to be performed, we have to set the `user` alias explicitly:

```elixir
@impl Backpex.LiveResource
def item_query(query, live_action, assigns) do
  query
  |> join(:left, [p], u in Demo.User, on: u.id == p.user_id, as: :user)
end
```
