### PR TITLE
Fix misplaced bracket in installation instructions

### DIFF
--- a/guides/get_started/installation.md
+++ b/guides/get_started/installation.md
@@ -272,7 +272,7 @@ So if you have this in your `root.html.heex`.
 
 ```html
 <body class="bg-white">
-</body> 
+</body>
 ```
 
 You should remove the `bg-white` class.
@@ -299,10 +299,10 @@ module.exports = {
           'primary-content': 'white',
           secondary: '#f39325',
           'secondary-content': 'white'
-        },
+        }
+      },
         "dark",
         "cyberpunk"
-      }
     ]
   },
   ...


### PR DESCRIPTION
Noted during setup that lsp was complaining in the config about misplaced closing brackets, so made a quick fix here. 