### PR TITLE
Make formatting for number fields optional

### DIFF
--- a/lib/backpex/html/html.ex
+++ b/lib/backpex/html/html.ex
@@ -15,7 +15,7 @@ defmodule Backpex.HTML do
       "—"
 
       iex> Backpex.HTML.pretty_value(1_000_000)
-      "1.000.000"
+      1000000
 
       iex> Backpex.HTML.pretty_value(1.11)
       1.11
@@ -26,9 +26,6 @@ defmodule Backpex.HTML do
   def pretty_value(input) when is_nil(input), do: "—"
 
   def pretty_value(""), do: "—"
-
-  def pretty_value(input) when is_integer(input),
-    do: Number.Delimit.number_to_delimited(input, precision: 0, delimiter: ".")
 
   def pretty_value(input), do: input
 end


### PR DESCRIPTION
This PR removes the formatting for a value of a number field. This should lead to the behavior that formatting is optional and is not carried out by default. 

Formatting of the number field must now be defined with the `render` option on the field itself. If number fields have benefited from the previous standard formatting, the following `render` function can now be used as an example:

```elixir
render: fn assigns ->
  ~H"""
  <p><%= Number.Delimit.number_to_delimited(@value, precision: 0, delimiter: ".") %></p>
  """
end
```