### PR TITLE
Fixed index_editable in Backpex.Fields.Number

### DIFF
--- a/lib/backpex/fields/number.ex
+++ b/lib/backpex/fields/number.ex
@@ -75,7 +75,7 @@ defmodule Backpex.Fields.Number do
   end
 
   @impl Phoenix.LiveComponent
-  def handle_event("update-field", %{"index_form" => %{"index_input" => value}}, socket) do
+  def handle_event("update-field", %{"index_form" => %{"value" => value}}, socket) do
     Backpex.Field.handle_index_editable(socket, value, Map.put(%{}, socket.assigns.name, value))
   end
 


### PR DESCRIPTION
Fixed index_editable in Backpex.Fields.Number

When `index_editable: true` is set in the field with Backpex.Fields.Number, it will fail to update.