### PR TITLE
Refactor caching steps in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,67 +38,50 @@ jobs:
           otp-version: ${{ matrix.erlang }}
           elixir-version: ${{ matrix.elixir }}
 
-      - name: Restore the deps cache
+      - name: Restore the deps and _build cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
-        id: deps-cache
+        id: restore-cache
+        env:
+          MIX_LOCK_HASH: ${{ hashFiles('/mix.lock') }}
         with:
-          path: deps
-          key: ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.erlang }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.erlang }}-deps-
-
-      - name: Restore the _build cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
-        id: build-cache
-        with:
-          path: _build
-          key: ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.erlang }}-build-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.erlang }}-build-
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.erlang }}-build-deps-mixlockhash-${{ env.MIX_LOCK_HASH }}
+          restore-keys:  ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.erlang }}-build-deps-
 
       - name: Install dependencies
-        if: steps.deps-cache.outputs.cache-hit != 'true'
-        run: |
-          mix local.hex --force --if-missing
-          mix local.rebar --force --if-missing
-          mix deps.get
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: mix deps.get
 
       - name: Compile dependencies
-        if: steps.deps-cache.outputs.cache-hit != 'true'
+        if: steps.restore-cache.outputs.cache-hit != 'true'
         run: mix deps.compile
 
       - name: Run tests
-        run: |
-          mix test
+        run: mix test
 
       - name: Check formatting
-        run: |
-          mix format --check-formatted
+        run: mix format --check-formatted
 
       - name: Compile with warnings as errors
-        run: |
-          mix compile --warnings-as-errors --force
+        run: mix compile --warnings-as-errors --force
 
       - name: Credo
-        run: |
-          mix credo
+        run: mix credo
 
       - name: Sobelow
-        run: |
-          mix sobelow --config
+        run: mix sobelow --config
 
       - name: Deps Unused
-        run: |
-          mix deps.unlock --check-unused
+        run: mix deps.unlock --check-unused
 
       - name: Deps Audit
         continue-on-error: true
-        run: |
-          mix deps.audit
+        run: mix deps.audit
 
       - name: Gettext Check
-        run: |
-          mix gettext.extract --check-up-to-date
+        run: mix gettext.extract --check-up-to-date
 
   publish:
     needs: test
@@ -162,41 +145,34 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: demo/yarn.lock
 
-      - name: Restore the deps cache
+      - name: Restore the deps and _build cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
-        id: deps-cache
+        id: restore-cache
+        env:
+          OTP_VERSION: ${{ steps.beam.outputs.otp-version }}
+          ELIXIR_VERSION: ${{ steps.beam.outputs.elixir-version }}
+          MIX_LOCK_HASH: ${{ hashFiles('/demo/mix.lock') }}
         with:
-          path: demo/deps
-          key: ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-deps-demo-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/demo/mix.lock')) }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-deps-demo-
-  
-      - name: Restore the _build cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
-        id: build-cache
-        with:
-          path: demo/_build
-          key: ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-build-demo-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/demo/mix.lock')) }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-build-demo-
-  
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-build-deps-demo-mixlockhash-${{ env.MIX_LOCK_HASH }}
+          restore-keys:  ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-build-deps-demo-
+
       - name: Install dependencies
-        if: steps.deps-cache.outputs.cache-hit != 'true'
+        if: steps.restore-cache.outputs.cache-hit != 'true'
         working-directory: demo
-        run: |
-          mix local.hex --force --if-missing
-          mix local.rebar --force --if-missing
-          mix deps.get
+        run: mix deps.get
+          
   
       - name: Compile dependencies
-        if: steps.deps-cache.outputs.cache-hit != 'true'
+        if: steps.restore-cache.outputs.cache-hit != 'true'
         working-directory: demo
         run: mix deps.compile
 
       - name: Compile with warnings as errors
         working-directory: demo
-        run: |
-          mix compile --warnings-as-errors --force
+        run: mix compile --warnings-as-errors --force
 
       - name: Install node dependencies
         working-directory: demo
@@ -204,38 +180,31 @@ jobs:
 
       - name: lint:mix
         working-directory: demo
-        run: |
-          yarn lint:mix
+        run: yarn lint:mix
 
       - name: lint:credo
         working-directory: demo
-        run: |
-          yarn lint:credo
+        run: yarn lint:credo
 
       - name: lint:sobelow
         working-directory: demo
-        run: |
-          yarn lint:sobelow
+        run: yarn lint:sobelow
 
       - name: lint:style
         working-directory: demo
-        run: |
-          yarn lint:style
+        run: yarn lint:style
 
       - name: lint:standard
         working-directory: demo
-        run: |
-          yarn lint:standard
+        run: yarn lint:standard
 
       - name: lint:deps-unused
         working-directory: demo
-        run: |
-          yarn lint:deps-unused
+        run: yarn lint:deps-unused
 
       - name: lint:gettext
         working-directory: demo
-        run: |
-          yarn lint:gettext
+        run: yarn lint:gettext
 
       - name: Run test
         working-directory: demo
@@ -244,14 +213,12 @@ jobs:
           DB_USERNAME: postgres
           DB_PASSWORD: postgres
           DB_DATABASE: test
-        run: |
-          yarn test
+        run: yarn test
 
       - name: Deps audit
         working-directory: demo
         continue-on-error: true
-        run: |
-          mix deps.audit
+        run: mix deps.audit
 
   build-runtime:
     name: "Build and push image (Demo)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,8 +154,8 @@ jobs:
           MIX_LOCK_HASH: ${{ hashFiles(format('{0}{1}', github.workspace, '/demo/mix.lock')) }}
         with:
           path: |
-            deps
-            _build
+            demo/deps
+            demo/_build
           key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-build-deps-demo-mixlockhash-${{ env.MIX_LOCK_HASH }}
           restore-keys:  ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-build-deps-demo-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         id: restore-cache
         env:
-          MIX_LOCK_HASH: ${{ hashFiles('/mix.lock') }}
+          MIX_LOCK_HASH: ${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
         with:
           path: |
             deps
@@ -151,7 +151,7 @@ jobs:
         env:
           OTP_VERSION: ${{ steps.beam.outputs.otp-version }}
           ELIXIR_VERSION: ${{ steps.beam.outputs.elixir-version }}
-          MIX_LOCK_HASH: ${{ hashFiles('/demo/mix.lock') }}
+          MIX_LOCK_HASH: ${{ hashFiles(format('{0}{1}', github.workspace, '/demo/mix.lock')) }}
         with:
           path: |
             deps


### PR DESCRIPTION
We always cache `deps` and `_build` directories. Therefore, I moved the two caching steps for `_build` and `deps` directories into one common caching step.