### PR TITLE
add formatter config to hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule Backpex.MixProject do
 
   defp package do
     [
-      files: ~w(lib priv mix.exs README.md LICENSE.md),
+      files: ~w(lib priv .formatter.exs mix.exs README.md LICENSE.md),
       maintainers: ["Florian Arens", "Phil-Bastian Berndt", "Simon Hansen"],
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url}


### PR DESCRIPTION
I think `.formatter.exs` was missing from the Hex package because formatting was not working in one of our projects.