### PR TITLE
Set `pinDigests` to false for ubuntu

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,12 @@
         "major"
       ],
       "enabled": false
+    },
+    {
+      "matchDepNames": [
+        "ubuntu"
+      ],
+      "pinDigests": false
     }
   ],
   "labels": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,9 @@
       "matchDepNames": [
         "ubuntu"
       ],
+      "matchDatasources": [
+        "docker"
+      ],
       "pinDigests": false
     }
   ],


### PR DESCRIPTION
Renovate cannot update the base image because it can't pin the ubuntu image.

> WARN: Error updating branch: update failure (branch="renovate/base-image")

```json
{
  "isPinDigest": true,
  "updateType": "pinDigest",
  "newValue": "jammy-20240808",
  "newDigest": "sha256:adbb90115a21969d2fe6fa7f9af4253e16d45f8d4c1e930182610c4731962658",
  "branchName": "renovate/base-image"
}
```