### PR TITLE
Improve generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,19 +18,19 @@ changelog:
     - title: Documentation
       labels:
         - documentation
-    - title: Dependency updates
+    - title: Dependency Updates
       labels:
         - dependencies
       exclude:
         labels:
           - demo
-    - title: Demo enhancements
+    - title: Demo Enhancements
       labels:
         - demo
       exclude:
         labels:
           - dependencies
-    - title: Demo dependency updates
+    - title: Demo Dependency Updates
       labels:
         - demo
         - dependencies

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -21,9 +21,19 @@ changelog:
     - title: Dependency updates
       labels:
         - dependencies
+      exclude:
+        labels:
+          - demo
     - title: Demo enhancements
       labels:
         - demo
+      exclude:
+        labels:
+          - dependencies
+    - title: Demo dependency updates
+      labels:
+        - demo
+        - dependencies
     - title: Other changes
       labels:
         - "*"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,9 +52,9 @@
       ]
     },
     {
-      "description": "Label updates to github-actions",
-      "matchManagers": [
-        "github-actions"
+      "description": "Label updates in ci.yml",
+      "matchFileNames": [
+        ".github/workflows/ci.yml"
       ],
       "labels": [
         "ignore-for-release",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -50,6 +50,17 @@
         "dependencies",
         "{{categories}}"
       ]
+    },
+    {
+      "description": "Label updates to github-actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "labels": [
+        "ignore-for-release",
+        "dependencies",
+        "{{categories}}"
+      ]
     }
   ],
   "labels": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
     "config:best-practices",
     "customManagers:dockerfileVersions",
     ":disableRateLimiting",
+    ":semanticCommitsDisabled",
     "github>pehbehbeh/renovate-config//workarounds/mixGitVersioning",
     "github>pehbehbeh/renovate-config//customManagers/hexEsbuild",
     "github>pehbehbeh/renovate-config//customManagers/hexTailwind",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,7 +21,7 @@
       ]
     },
     {
-      "description": "Disable ubuntu major updates",
+      "description": "Disable Ubuntu major updates",
       "matchDepNames": [
         "ubuntu"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,7 @@
   ],
   "packageRules": [
     {
+      "description": "Group updates to the Elixir base image",
       "groupName": "Base Image",
       "matchDepNames": [
         "erlang",
@@ -20,6 +21,7 @@
       ]
     },
     {
+      "description": "Disable ubuntu major updates",
       "matchDepNames": [
         "ubuntu"
       ],
@@ -29,6 +31,7 @@
       "enabled": false
     },
     {
+      "description": "Disable digest pinning for Ubuntu",
       "matchDepNames": [
         "ubuntu"
       ],
@@ -36,6 +39,17 @@
         "docker"
       ],
       "pinDigests": false
+    },
+    {
+      "description": "Label updates in demo directory",
+      "matchFileNames": [
+        "demo/**"
+      ],
+      "labels": [
+        "demo",
+        "dependencies",
+        "{{categories}}"
+      ]
     }
   ],
   "labels": [


### PR DESCRIPTION
I noticed that we have a "Dependency Updates" section in our release notes that includes both backpex and demo dependency updates. We should not include demo dependency updates there because they do not affect most users. I have added a new "Demo Dependency Updates" section and made some improvements to our release notes.

- Disable semantic commits for renovate (looks better in the changelog / release notes)
- Add `demo` label to dependency updates in /demo directory
- Add "Demo Dependency Updates" section to release notes
- Add descriptions to all renovate package rules
- Add `ignore-for-release` label to updates in `.github/workflows/ci.yml` (there is no need to include these udates in our release notes)