### PR TITLE
Refactor `field_input` component

### DIFF
--- a/guides/fields/custom-fields.md
+++ b/guides/fields/custom-fields.md
@@ -32,7 +32,7 @@ def render_form(assigns) do
     <:label>
         <Layout.input_label text={@field_options[:label]} />
     </:label>
-    <BackpexForm.field_input
+    <BackpexForm.input
         type="text"
         field={@form[@name]}
         translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}

--- a/guides/fields/custom-fields.md
+++ b/guides/fields/custom-fields.md
@@ -32,7 +32,13 @@ def render_form(assigns) do
     <:label>
         <Layout.input_label text={@field_options[:label]} />
     </:label>
-    <BackpexForm.field_input type="text" form={@form} field_name={@name} field_options={@field_options} />
+    <BackpexForm.field_input
+        type="text"
+        field={@form[@name]}
+        translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+        phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+        phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+    />
     </Layout.field_container>
 </div>
 """

--- a/guides/fields/readonly.md
+++ b/guides/fields/readonly.md
@@ -60,7 +60,7 @@ def render_form_readonly(assigns) do
         <:label>
             <Layout.input_label text={@field[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
         type="text"
         field={@form[@name]}
         translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}

--- a/guides/fields/readonly.md
+++ b/guides/fields/readonly.md
@@ -61,12 +61,13 @@ def render_form_readonly(assigns) do
             <Layout.input_label text={@field[:label]} />
         </:label>
         <BackpexForm.field_input
-            type="text"
-            form={@form}
-            field_name={@name}
-            field_options={@field_options}
-            readonly
-            disabled
+        type="text"
+        field={@form[@name]}
+        translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+        phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+        phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+        readonly
+        disabled
         />
     </Layout.field_container>
 </div>

--- a/guides/upgrading/v0.9.md
+++ b/guides/upgrading/v0.9.md
@@ -1,0 +1,68 @@
+# Upgrading to v0.9
+
+## Bump your deps
+
+Update Backpex to the latest version:
+
+```elixir
+  defp deps do
+    [
+      {:backpex, "~> 0.9.0"}
+    ]
+  end
+```
+
+
+## Refactor calls to [`Backpex.HTML.Form.field_input/1`]()
+
+We've refactored the [`Backpex.HTML.Form.field_input/1`]() component and renamed it to `Backpex.HTML.Form.input/1`.
+
+- It doesn't rely on a `field_options` map anymore (instead all options must be passed explicitly)
+- It now supports lists for all class attributes (`class`, `input_class` and `input_wrapper_class`)
+- It now accepts a `translate_error_fun` attribute
+
+In addition, the `input_class` and `input_wrapper_class` attributes now completely override the defaults.
+
+Make sure to update your calls to [`Backpex.HTML.Form.field_input/1`](). This may apply to your custom fields as well.
+
+Before:
+
+```elixir
+@impl Backpex.Field
+def render_form(assigns) do
+  ~H"""
+  <div>
+    <Layout.field_container>
+      <:label align={Backpex.Field.align_label(@field_options, assigns, :center)}>
+        <Layout.input_label text={@field_options[:label]} />
+      </:label>
+      <BackpexForm.field_input type="text" field={@form[@name]} field_options={@field_options} />
+    </Layout.field_container>
+  </div>
+  """
+end
+```
+
+After:
+
+```elixir
+@impl Backpex.Field
+def render_form(assigns) do
+  ~H"""
+  <div>
+    <Layout.field_container>
+      <:label align={Backpex.Field.align_label(@field_options, assigns, :center)}>
+        <Layout.input_label text={@field_options[:label]} />
+      </:label>
+      <BackpexForm.input
+        type="text"
+        field={@form[@name]}
+        translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+        phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+        phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+      />
+    </Layout.field_container>
+  </div>
+  """
+end
+```

--- a/lib/backpex/field.ex
+++ b/lib/backpex/field.ex
@@ -188,29 +188,34 @@ defmodule Backpex.Field do
   Defines placeholder value.
   """
   def placeholder(%{placeholder: placeholder}, _assigns) when is_binary(placeholder), do: placeholder
-  def placeholder(%{placeholder: placeholder}, assigns) when is_function(placeholder), do: placeholder.(assigns)
+  def placeholder(%{placeholder: placeholder}, assigns) when is_function(placeholder, 1), do: placeholder.(assigns)
   def placeholder(_field, _assigns), do: nil
 
   @doc """
   Defines debounce timeout value.
   """
   def debounce(%{debounce: debounce}, _assigns) when is_binary(debounce) or is_integer(debounce), do: debounce
-  def debounce(%{debounce: debounce}, assigns) when is_function(debounce), do: debounce.(assigns)
+  def debounce(%{debounce: debounce}, assigns) when is_function(debounce, 1), do: debounce.(assigns)
   def debounce(_field, _assigns), do: nil
 
   @doc """
   Defines throttle timeout value.
   """
   def throttle(%{throttle: throttle}, _assigns) when is_binary(throttle) or is_integer(throttle), do: throttle
-  def throttle(%{throttle: throttle}, assigns) when is_function(throttle), do: throttle.(assigns)
+  def throttle(%{throttle: throttle}, assigns) when is_function(throttle, 1), do: throttle.(assigns)
   def throttle(_field, _assigns), do: nil
 
   @doc """
   Determines whether the field should be rendered as readonly version.
   """
   def readonly?(%{readonly: readonly}, _assigns) when is_boolean(readonly), do: readonly
-  def readonly?(%{readonly: readonly}, assigns) when is_function(readonly), do: readonly.(assigns)
+  def readonly?(%{readonly: readonly}, assigns) when is_function(readonly, 1), do: readonly.(assigns)
   def readonly?(_field_options, _assigns), do: false
+
+  def translate_error_fun(%{translate_error: translate_error}, _assigns) when is_function(translate_error, 1),
+    do: translate_error
+
+  def translate_error_fun(_field_options, _assigns), do: &Function.identity/1
 
   @doc """
   Gets alignment option for label.

--- a/lib/backpex/fields/belongs_to.ex
+++ b/lib/backpex/fields/belongs_to.ex
@@ -113,9 +113,11 @@ defmodule Backpex.Fields.BelongsTo do
         <BackpexForm.field_input
           type="select"
           field={@form[@owner_key]}
-          field_options={@field_options}
           options={@options}
           prompt={@prompt}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
         />
       </Layout.field_container>
     </div>
@@ -140,14 +142,17 @@ defmodule Backpex.Fields.BelongsTo do
     ~H"""
     <div>
       <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
-        <select
-          name={@form[:value].name}
-          class={["select select-sm", if(@valid, do: "hover:input-bordered", else: "select-error")]}
+        <BackpexForm.field_input
+          type="select"
+          field={@form[:value]}
+          options={@options}
+          prompt={@prompt}
+          value={@value && Map.get(@value, :id)}
+          input_wrapper_class=""
+          input_class={["select select-sm", if(@valid, do: "hover:input-bordered", else: "select-error")]}
           disabled={@readonly}
-        >
-          <option :if={@prompt} value=""><%= @prompt %></option>
-          <%= Phoenix.HTML.Form.options_for_select(@options, @value && Map.get(@value, :id)) %>
-        </select>
+          hide_errors
+        />
       </.form>
     </div>
     """

--- a/lib/backpex/fields/belongs_to.ex
+++ b/lib/backpex/fields/belongs_to.ex
@@ -110,7 +110,7 @@ defmodule Backpex.Fields.BelongsTo do
         <:label align={Backpex.Field.align_label(@field_options, assigns)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="select"
           field={@form[@owner_key]}
           options={@options}
@@ -142,7 +142,7 @@ defmodule Backpex.Fields.BelongsTo do
     ~H"""
     <div>
       <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="select"
           field={@form[:value]}
           options={@options}

--- a/lib/backpex/fields/boolean.ex
+++ b/lib/backpex/fields/boolean.ex
@@ -27,7 +27,13 @@ defmodule Backpex.Fields.Boolean do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input type="toggle" field={@form[@name]} field_options={@field_options} />
+        <BackpexForm.field_input
+          type="toggle"
+          field={@form[@name]}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+        />
       </Layout.field_container>
     </div>
     """

--- a/lib/backpex/fields/boolean.ex
+++ b/lib/backpex/fields/boolean.ex
@@ -27,7 +27,7 @@ defmodule Backpex.Fields.Boolean do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="toggle"
           field={@form[@name]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}

--- a/lib/backpex/fields/currency.ex
+++ b/lib/backpex/fields/currency.ex
@@ -64,7 +64,6 @@ defmodule Backpex.Fields.Currency do
         <BackpexForm.input
           type="number"
           field={@form[@name]}
-          field_options={@field_options}
           value={@casted_value}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}

--- a/lib/backpex/fields/currency.ex
+++ b/lib/backpex/fields/currency.ex
@@ -61,7 +61,7 @@ defmodule Backpex.Fields.Currency do
         <:label align={Backpex.Field.align_label(@field_options, assigns)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="number"
           field={@form[@name]}
           field_options={@field_options}

--- a/lib/backpex/fields/date.ex
+++ b/lib/backpex/fields/date.ex
@@ -88,7 +88,7 @@ defmodule Backpex.Fields.Date do
         <BackpexForm.field_input
           type="date"
           field={@form[@name]}
-          field_options={@field_options}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
         />
@@ -108,7 +108,7 @@ defmodule Backpex.Fields.Date do
         <BackpexForm.field_input
           type="date"
           field={@form[@name]}
-          field_options={@field_options}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
           readonly
@@ -131,13 +131,13 @@ defmodule Backpex.Fields.Date do
     ~H"""
     <div>
       <.form for={@form} phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
-        <input
+        <BackpexForm.field_input
           type="date"
-          name={@form[:value].name}
-          value={@form[:value].value}
-          class={["input input-sm w-32", @valid && "hover:input-bordered", !@valid && "input-error"]}
+          field={@form[:value]}
+          input_class={["input input-sm w-52", @valid && "hover:input-bordered", !@valid && "input-error"]}
           phx-debounce="100"
           readonly={@readonly}
+          hide_errors
         />
       </.form>
     </div>

--- a/lib/backpex/fields/date.ex
+++ b/lib/backpex/fields/date.ex
@@ -85,7 +85,7 @@ defmodule Backpex.Fields.Date do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="date"
           field={@form[@name]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
@@ -105,7 +105,7 @@ defmodule Backpex.Fields.Date do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="date"
           field={@form[@name]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
@@ -131,7 +131,7 @@ defmodule Backpex.Fields.Date do
     ~H"""
     <div>
       <.form for={@form} phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="date"
           field={@form[:value]}
           input_class={["input input-sm w-52", @valid && "hover:input-bordered", !@valid && "input-error"]}

--- a/lib/backpex/fields/date_time.ex
+++ b/lib/backpex/fields/date_time.ex
@@ -88,7 +88,7 @@ defmodule Backpex.Fields.DateTime do
         <BackpexForm.field_input
           type="datetime-local"
           field={@form[@name]}
-          field_options={@field_options}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
         />
@@ -108,7 +108,7 @@ defmodule Backpex.Fields.DateTime do
         <BackpexForm.field_input
           type="datetime-local"
           field={@form[@name]}
-          field_options={@field_options}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
           readonly
@@ -131,13 +131,13 @@ defmodule Backpex.Fields.DateTime do
     ~H"""
     <div>
       <.form for={@form} phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
-        <input
+        <BackpexForm.field_input
           type="datetime-local"
-          name={@form[:value].name}
-          value={@form[:value].value}
-          class={["input input-sm w-52", @valid && "hover:input-bordered", !@valid && "input-error"]}
+          field={@form[:value]}
+          input_class={["input input-sm w-52", @valid && "hover:input-bordered", !@valid && "input-error"]}
           phx-debounce="100"
           readonly={@readonly}
+          hide_errors
         />
       </.form>
     </div>

--- a/lib/backpex/fields/date_time.ex
+++ b/lib/backpex/fields/date_time.ex
@@ -85,7 +85,7 @@ defmodule Backpex.Fields.DateTime do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="datetime-local"
           field={@form[@name]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
@@ -105,7 +105,7 @@ defmodule Backpex.Fields.DateTime do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="datetime-local"
           field={@form[@name]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
@@ -131,7 +131,7 @@ defmodule Backpex.Fields.DateTime do
     ~H"""
     <div>
       <.form for={@form} phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="datetime-local"
           field={@form[:value]}
           input_class={["input input-sm w-52", @valid && "hover:input-bordered", !@valid && "input-error"]}

--- a/lib/backpex/fields/has_many.ex
+++ b/lib/backpex/fields/has_many.ex
@@ -501,7 +501,9 @@ defmodule Backpex.Fields.HasMany do
   defp assign_form_errors(socket) do
     %{assigns: %{form: form, name: name, field_options: field_options}} = socket
 
-    assign(socket, :errors, translate_form_errors(form[name], field_options))
+    translate_error_fun = Map.get(field_options, :translate_error, &Function.identity/1)
+
+    assign(socket, :errors, translate_form_errors(form[name], translate_error_fun))
   end
 
   defp query_limit(field_options), do: Map.get(field_options, :query_limit, 10)

--- a/lib/backpex/fields/has_many_through.ex
+++ b/lib/backpex/fields/has_many_through.ex
@@ -536,7 +536,14 @@ defmodule Backpex.Fields.HasManyThrough do
       <:label>
         <Layout.input_label text={@label} />
       </:label>
-      <BackpexForm.field_input type="select" field={@form[@owner_key]} field_options={@field_options} options={@options} />
+      <BackpexForm.field_input
+        type="select"
+        field={@form[@owner_key]}
+        options={@options}
+        translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+        phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+        phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+      />
     </Layout.field_container>
     """
   end

--- a/lib/backpex/fields/has_many_through.ex
+++ b/lib/backpex/fields/has_many_through.ex
@@ -536,7 +536,7 @@ defmodule Backpex.Fields.HasManyThrough do
       <:label>
         <Layout.input_label text={@label} />
       </:label>
-      <BackpexForm.field_input
+      <BackpexForm.input
         type="select"
         field={@form[@owner_key]}
         options={@options}

--- a/lib/backpex/fields/inline_crud.ex
+++ b/lib/backpex/fields/inline_crud.ex
@@ -132,7 +132,9 @@ defmodule Backpex.Fields.InlineCRUD do
                 <BackpexForm.field_input
                   type={input_type(child_field_options) |> Atom.to_string()}
                   field={f_nested[child_field_name]}
-                  field_options={child_field_options}
+                  translate_error_fun={Backpex.Field.translate_error_fun(child_field_options, assigns)}
+                  phx-debounce={Backpex.Field.debounce(child_field_options, assigns)}
+                  phx-throttle={Backpex.Field.throttle(child_field_options, assigns)}
                 />
               </div>
 

--- a/lib/backpex/fields/inline_crud.ex
+++ b/lib/backpex/fields/inline_crud.ex
@@ -129,7 +129,7 @@ defmodule Backpex.Fields.InlineCRUD do
                 <p :if={f_nested.index == 0} class="mb-1 text-xs">
                   <%= child_field_options.label %>
                 </p>
-                <BackpexForm.field_input
+                <BackpexForm.input
                   type={input_type(child_field_options) |> Atom.to_string()}
                   field={f_nested[child_field_name]}
                   translate_error_fun={Backpex.Field.translate_error_fun(child_field_options, assigns)}

--- a/lib/backpex/fields/number.ex
+++ b/lib/backpex/fields/number.ex
@@ -29,7 +29,13 @@ defmodule Backpex.Fields.Number do
         <:label align={Backpex.Field.align_label(@field_options, assigns)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input type="text" field={@form[@name]} field_options={@field_options} />
+        <BackpexForm.field_input
+          type="text"
+          field={@form[@name]}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+        />
       </Layout.field_container>
     </div>
     """
@@ -43,7 +49,15 @@ defmodule Backpex.Fields.Number do
         <:label align={Backpex.Field.align_label(@field_options, assigns)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input type="text" field={@form[@name]} field_options={@field_options} readonly disabled />
+        <BackpexForm.field_input
+          type="text"
+          field={@form[@name]}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+          readonly
+          disabled
+        />
       </Layout.field_container>
     </div>
     """
@@ -61,13 +75,13 @@ defmodule Backpex.Fields.Number do
     ~H"""
     <div>
       <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
-        <input
+        <BackpexForm.field_input
           type="text"
-          name={@form[:value].name}
-          value={@form[:value].value}
-          class={["input input-sm", @valid && "hover:input-bordered", !@valid && "input-error"]}
+          field={@form[:value]}
+          input_class={["input input-sm", @valid && "hover:input-bordered", !@valid && "input-error bg-error/10"]}
           phx-debounce="100"
           readonly={@readonly}
+          hide_errors
         />
       </.form>
     </div>

--- a/lib/backpex/fields/number.ex
+++ b/lib/backpex/fields/number.ex
@@ -29,7 +29,7 @@ defmodule Backpex.Fields.Number do
         <:label align={Backpex.Field.align_label(@field_options, assigns)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="text"
           field={@form[@name]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
@@ -49,7 +49,7 @@ defmodule Backpex.Fields.Number do
         <:label align={Backpex.Field.align_label(@field_options, assigns)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="text"
           field={@form[@name]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
@@ -75,7 +75,7 @@ defmodule Backpex.Fields.Number do
     ~H"""
     <div>
       <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="text"
           field={@form[:value]}
           input_class={["input input-sm", @valid && "hover:input-bordered", !@valid && "input-error bg-error/10"]}

--- a/lib/backpex/fields/select.ex
+++ b/lib/backpex/fields/select.ex
@@ -51,7 +51,7 @@ defmodule Backpex.Fields.Select do
         <:label align={Backpex.Field.align_label(@field_options, assigns)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="select"
           field={@form[@name]}
           options={@options}
@@ -80,7 +80,7 @@ defmodule Backpex.Fields.Select do
     ~H"""
     <div>
       <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="select"
           field={@form[:value]}
           options={@options}

--- a/lib/backpex/fields/select.ex
+++ b/lib/backpex/fields/select.ex
@@ -54,9 +54,11 @@ defmodule Backpex.Fields.Select do
         <BackpexForm.field_input
           type="select"
           field={@form[@name]}
-          field_options={@field_options}
           options={@options}
           prompt={@prompt}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
         />
       </Layout.field_container>
     </div>
@@ -78,14 +80,16 @@ defmodule Backpex.Fields.Select do
     ~H"""
     <div>
       <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
-        <select
-          name={@form[:value].name}
-          class={["select select-sm", if(@valid, do: "hover:input-bordered", else: "select-error")]}
+        <BackpexForm.field_input
+          type="select"
+          field={@form[:value]}
+          options={@options}
+          prompt={@prompt}
+          input_wrapper_class=""
+          input_class={["select select-sm", if(@valid, do: "hover:input-bordered", else: "select-error")]}
           disabled={@readonly}
-        >
-          <option :if={@prompt} value=""><%= @prompt %></option>
-          <%= Phoenix.HTML.Form.options_for_select(@options, @form[:value].value) %>
-        </select>
+          hide_errors
+        />
       </.form>
     </div>
     """

--- a/lib/backpex/fields/text.ex
+++ b/lib/backpex/fields/text.ex
@@ -27,7 +27,7 @@ defmodule Backpex.Fields.Text do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :center)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="text"
           field={@form[@name]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
@@ -47,7 +47,7 @@ defmodule Backpex.Fields.Text do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :center)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="text"
           field={@form[@name]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
@@ -73,7 +73,7 @@ defmodule Backpex.Fields.Text do
     ~H"""
     <div>
       <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="text"
           field={@form[:value]}
           input_class={["input input-sm", @valid && "hover:input-bordered", !@valid && "input-error bg-error/10"]}

--- a/lib/backpex/fields/text.ex
+++ b/lib/backpex/fields/text.ex
@@ -27,7 +27,13 @@ defmodule Backpex.Fields.Text do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :center)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input type="text" field={@form[@name]} field_options={@field_options} />
+        <BackpexForm.field_input
+          type="text"
+          field={@form[@name]}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+        />
       </Layout.field_container>
     </div>
     """
@@ -41,7 +47,15 @@ defmodule Backpex.Fields.Text do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :center)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input type="text" field={@form[@name]} field_options={@field_options} readonly disabled />
+        <BackpexForm.field_input
+          type="text"
+          field={@form[@name]}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+          readonly
+          disabled
+        />
       </Layout.field_container>
     </div>
     """
@@ -59,13 +73,13 @@ defmodule Backpex.Fields.Text do
     ~H"""
     <div>
       <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
-        <input
+        <BackpexForm.field_input
           type="text"
-          name={@form[:value].name}
-          value={@form[:value].value}
-          class={["input input-sm", @valid && "hover:input-bordered", !@valid && "input-error"]}
+          field={@form[:value]}
+          input_class={["input input-sm", @valid && "hover:input-bordered", !@valid && "input-error bg-error/10"]}
           phx-debounce="100"
           readonly={@readonly}
+          hide_errors
         />
       </.form>
     </div>

--- a/lib/backpex/fields/textarea.ex
+++ b/lib/backpex/fields/textarea.ex
@@ -31,7 +31,7 @@ defmodule Backpex.Fields.Textarea do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="textarea"
           field={@form[@name]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
@@ -51,7 +51,7 @@ defmodule Backpex.Fields.Textarea do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="textarea"
           field={@form[@name]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}

--- a/lib/backpex/fields/textarea.ex
+++ b/lib/backpex/fields/textarea.ex
@@ -31,7 +31,13 @@ defmodule Backpex.Fields.Textarea do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input type="textarea" field={@form[@name]} field_options={@field_options} />
+        <BackpexForm.field_input
+          type="textarea"
+          field={@form[@name]}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+        />
       </Layout.field_container>
     </div>
     """
@@ -45,7 +51,15 @@ defmodule Backpex.Fields.Textarea do
         <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input type="textarea" field={@form[@name]} field_options={@field_options} readonly disabled />
+        <BackpexForm.field_input
+          type="textarea"
+          field={@form[@name]}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+          readonly
+          disabled
+        />
       </Layout.field_container>
     </div>
     """

--- a/lib/backpex/fields/upload.ex
+++ b/lib/backpex/fields/upload.ex
@@ -386,7 +386,8 @@ defmodule Backpex.Fields.Upload do
   def render_form(assigns) do
     upload_key = assigns.field_options.upload_key
     uploads_allowed = not is_nil(assigns.field_uploads)
-    form_errors = BackpexForm.translate_form_errors(assigns.form[assigns.name], assigns.field_options)
+    translate_error_fun = Map.get(assigns.field_options, :translate_error, &Function.identity/1)
+    form_errors = BackpexForm.translate_form_errors(assigns.form[assigns.name], translate_error_fun)
 
     assigns =
       assigns

--- a/lib/backpex/fields/url.ex
+++ b/lib/backpex/fields/url.ex
@@ -29,7 +29,13 @@ defmodule Backpex.Fields.URL do
         <:label align={Backpex.Field.align_label(@field_options, assigns)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input type="text" field={@form[@name]} field_options={@field_options} />
+        <BackpexForm.field_input
+          type="text"
+          field={@form[@name]}
+          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+        />
       </Layout.field_container>
     </div>
     """

--- a/lib/backpex/fields/url.ex
+++ b/lib/backpex/fields/url.ex
@@ -29,7 +29,7 @@ defmodule Backpex.Fields.URL do
         <:label align={Backpex.Field.align_label(@field_options, assigns)}>
           <Layout.input_label text={@field_options[:label]} />
         </:label>
-        <BackpexForm.field_input
+        <BackpexForm.input
           type="text"
           field={@form[@name]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}

--- a/lib/backpex/html/form.ex
+++ b/lib/backpex/html/form.ex
@@ -39,7 +39,6 @@ defmodule Backpex.HTML.Form do
     default: nil,
     doc: "additional class for the input wrapper element, currently only used in select type"
 
-  attr :field_options, :map, default: %{}, doc: "field options map"
   attr :translate_error_fun, :any, default: &Function.identity/1, doc: "TODO"
   attr :hide_errors, :boolean, default: false, doc: "if errors should be hidden"
 

--- a/lib/backpex/html/form.ex
+++ b/lib/backpex/html/form.ex
@@ -45,16 +45,16 @@ defmodule Backpex.HTML.Form do
 
   slot :inner_block
 
-  def field_input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
+  def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
     assigns
     |> assign(field: nil, id: assigns.id || field.id)
     |> assign(:errors, translate_form_errors(field, assigns.translate_error_fun))
     |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
     |> assign_new(:value, fn -> field.value end)
-    |> field_input()
+    |> input()
   end
 
-  def field_input(%{type: "checkbox"} = assigns) do
+  def input(%{type: "checkbox"} = assigns) do
     assigns = assign_new(assigns, :checked, fn -> Form.normalize_value("checkbox", assigns.value) end)
 
     ~H"""
@@ -106,7 +106,7 @@ defmodule Backpex.HTML.Form do
     """
   end
 
-  def field_input(%{type: "toggle"} = assigns) do
+  def input(%{type: "toggle"} = assigns) do
     assigns = assign_new(assigns, :checked, fn -> Form.normalize_value("checkbox", assigns.value) end)
 
     ~H"""
@@ -158,7 +158,7 @@ defmodule Backpex.HTML.Form do
     """
   end
 
-  def field_input(%{type: "select"} = assigns) do
+  def input(%{type: "select"} = assigns) do
     ~H"""
     <div phx-feedback-for={@name} class={@class}>
       <div class="form-control">
@@ -184,7 +184,7 @@ defmodule Backpex.HTML.Form do
     """
   end
 
-  def field_input(%{type: "textarea"} = assigns) do
+  def input(%{type: "textarea"} = assigns) do
     ~H"""
     <div phx-feedback-for={@name} class={@class}>
       <div class="form-control">
@@ -210,7 +210,7 @@ defmodule Backpex.HTML.Form do
     """
   end
 
-  def field_input(assigns) do
+  def input(assigns) do
     ~H"""
     <div phx-feedback-for={@name} class={@class}>
       <div class="form-control">

--- a/lib/backpex/html/form.ex
+++ b/lib/backpex/html/form.ex
@@ -32,10 +32,10 @@ defmodule Backpex.HTML.Form do
   attr :rest, :global, include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
                 multiple pattern placeholder readonly required rows size step)
 
-  attr :class, :string, default: nil, doc: "additional class"
-  attr :input_class, :string, default: nil, doc: "additional class for the input element"
+  attr :class, :any, default: nil, doc: "additional class for the container"
+  attr :input_class, :any, default: nil, doc: "additional class for the input element"
 
-  attr :input_wrapper_class, :string,
+  attr :input_wrapper_class, :any,
     default: nil,
     doc: "additional class for the input wrapper element, currently only used in select type"
 

--- a/mix.exs
+++ b/mix.exs
@@ -167,6 +167,7 @@ defmodule Backpex.MixProject do
       "guides/custom_labels_and_translations/custom-labels-and-translations.md",
 
       # Upgrade Guides
+      "guides/upgrading/v0.9.md",
       "guides/upgrading/v0.8.md",
       "guides/upgrading/v0.7.md",
       "guides/upgrading/v0.6.md",


### PR DESCRIPTION
closes #354 

I made `field_input` component more generic by not relying on a `field_options` map anymore. I also renamed the component to `input`.

- Rename `field_input` component to `input`
- Remove `field_options` attribute from `input` component
- Add `translate_error_fun` attribute for custom error translations
- Change type `string` to `any` for class attributes passed to `input` component (mainly to include lists, too)
- Refactor all `field_input` calls