### PR TITLE
Refactor Long Quote Block in LiveResource

### DIFF
--- a/guides/upgrading/v0.9.md
+++ b/guides/upgrading/v0.9.md
@@ -12,7 +12,6 @@ Update Backpex to the latest version:
   end
 ```
 
-
 ## Refactor calls to [`Backpex.HTML.Form.field_input/1`]()
 
 We've refactored the [`Backpex.HTML.Form.field_input/1`]() component and renamed it to `Backpex.HTML.Form.input/1`.
@@ -66,3 +65,8 @@ def render_form(assigns) do
   """
 end
 ```
+
+## `Backpex.LiveResource` function usage
+
+Although the change is relatively small, if you are using public functions of the `Backpex.LiveResource` directly,
+check the updated function definitions in the module documentation.

--- a/lib/backpex/adapters/ecto.ex
+++ b/lib/backpex/adapters/ecto.ex
@@ -132,7 +132,7 @@ defmodule Backpex.Adapters.Ecto do
     |> maybe_preload(associations, fields)
     |> maybe_merge_dynamic_fields(fields)
     |> apply_search(schema, full_text_search, criteria[:search])
-    |> apply_filters(criteria[:filters], Backpex.LiveResource.get_empty_filter_key())
+    |> apply_filters(criteria[:filters], Backpex.LiveResource.empty_filter_key())
     |> apply_criteria(criteria, fields)
   end
 

--- a/lib/backpex/adapters/ecto.ex
+++ b/lib/backpex/adapters/ecto.ex
@@ -122,7 +122,7 @@ defmodule Backpex.Adapters.Ecto do
   TODO: Should be private.
   """
   def list_query(assigns, item_query, fields, criteria \\ []) do
-    %{schema: schema, full_text_search: full_text_search, live_resource: live_resource} = assigns
+    %{schema: schema, full_text_search: full_text_search} = assigns
     associations = associations(fields, schema)
 
     schema
@@ -132,7 +132,7 @@ defmodule Backpex.Adapters.Ecto do
     |> maybe_preload(associations, fields)
     |> maybe_merge_dynamic_fields(fields)
     |> apply_search(schema, full_text_search, criteria[:search])
-    |> apply_filters(criteria[:filters], live_resource.get_empty_filter_key())
+    |> apply_filters(criteria[:filters], Backpex.LiveResource.get_empty_filter_key())
     |> apply_criteria(criteria, fields)
   end
 

--- a/lib/backpex/field.ex
+++ b/lib/backpex/field.ex
@@ -255,11 +255,11 @@ defmodule Backpex.Field do
   Handles index editable.
   """
   def handle_index_editable(socket, value, change) do
-    if not Backpex.LiveResource.can?(socket.assigns, :edit, socket.assigns.item, socket.assigns.live_resource) do
+    %{assigns: %{item: item, live_resource: live_resource, fields: fields} = assigns} = socket
+
+    if not live_resource.can?(assigns, :edit, item) do
       raise Backpex.ForbiddenError
     end
-
-    %{assigns: %{item: item, live_resource: live_resource, fields: fields} = assigns} = socket
 
     opts = [
       after_save_fun: fn item ->

--- a/lib/backpex/fields/belongs_to.ex
+++ b/lib/backpex/fields/belongs_to.ex
@@ -30,7 +30,6 @@ defmodule Backpex.Fields.BelongsTo do
 
   import Ecto.Query
 
-  alias Backpex.LiveResource
   alias Backpex.Router
 
   @impl Phoenix.LiveComponent
@@ -189,7 +188,7 @@ defmodule Backpex.Fields.BelongsTo do
       assigns
 
     link =
-      if Map.has_key?(field_options, :live_resource) and LiveResource.can?(assigns, :show, value, live_resource) do
+      if Map.has_key?(field_options, :live_resource) and live_resource.can?(assigns, :show, value) do
         Router.get_path(socket, Map.get(field_options, :live_resource), params, :show, value)
       else
         nil

--- a/lib/backpex/fields/has_many.ex
+++ b/lib/backpex/fields/has_many.ex
@@ -335,13 +335,12 @@ defmodule Backpex.Fields.HasMany do
       socket: socket,
       field_options: field_options,
       item: item,
-      live_resource: live_resource,
       params: params,
       link_assocs: link_assocs
     } = assigns
 
     link =
-      if link_assocs and Map.has_key?(field_options, :live_resource) and live_resource.can?(assigns, :show, item) do
+      if link_assocs and field_options.live_resource.can?(assigns, :show, item) do
         Router.get_path(socket, Map.get(field_options, :live_resource), params, :show, item)
       else
         nil

--- a/lib/backpex/fields/has_many.ex
+++ b/lib/backpex/fields/has_many.ex
@@ -39,7 +39,6 @@ defmodule Backpex.Fields.HasMany do
   import Ecto.Query
   import Backpex.HTML.Form
   alias Backpex.Adapters.Ecto, as: EctoAdapter
-  alias Backpex.LiveResource
   alias Backpex.Router
 
   @impl Phoenix.LiveComponent
@@ -341,8 +340,7 @@ defmodule Backpex.Fields.HasMany do
     } = assigns
 
     link =
-      if link_assocs and Map.has_key?(field_options, :live_resource) and
-           LiveResource.can?(assigns, :show, item, live_resource) do
+      if link_assocs and Map.has_key?(field_options, :live_resource) and live_resource.can?(assigns, :show, item) do
         Router.get_path(socket, Map.get(field_options, :live_resource), params, :show, item)
       else
         nil

--- a/lib/backpex/fields/has_many.ex
+++ b/lib/backpex/fields/has_many.ex
@@ -255,7 +255,8 @@ defmodule Backpex.Fields.HasMany do
     {field_name, field_options} = field
     validate_live_resource(field_name, field_options)
 
-    schema = field_options.live_resource.schema()
+    # TODO: do not rely on specific adapter
+    schema = field_options.live_resource.config(:adapter_config)[:schema]
     field_name_string = to_string(field_name)
 
     new_assocs = get_new_assocs(attrs, field_name_string, schema, repo, field_options, assigns)

--- a/lib/backpex/html/resource.ex
+++ b/lib/backpex/html/resource.ex
@@ -105,7 +105,7 @@ defmodule Backpex.HTML.Resource do
     {_name, field_options} = field = Enum.find(fields, fn {field_name, _field_options} -> field_name == name end)
 
     readonly =
-      not LiveResource.can?(assigns, :edit, item, live_resource) or
+      not live_resource.can?(assigns, :edit, item) or
         Backpex.Field.readonly?(field_options, assigns)
 
     assigns =
@@ -627,7 +627,7 @@ defmodule Backpex.HTML.Resource do
     ~H"""
     <div class="mb-4 flex space-x-2">
       <.link
-        :if={LiveResource.can?(assigns, :new, nil, @live_resource)}
+        :if={@live_resource.can?(assigns, :new, nil)}
         patch={Router.get_path(@socket, @live_resource, @params, :new)}
       >
         <button class="btn btn-sm btn-outline btn-primary">
@@ -703,7 +703,7 @@ defmodule Backpex.HTML.Resource do
 
   defp resource_actions(assigns, resource_actions) do
     Enum.filter(resource_actions, fn {key, _action} ->
-      LiveResource.can?(assigns, key, nil, assigns.live_resource)
+      assigns.live_resource.can?(assigns, key, nil, assigns)
     end)
   end
 
@@ -712,7 +712,7 @@ defmodule Backpex.HTML.Resource do
     resource_actions = resource_actions(assigns, assigns.resource_actions)
 
     Enum.any?(index_item_actions) &&
-      (Enum.any?(resource_actions) || LiveResource.can?(assigns, :new, nil, assigns.live_resource))
+      (Enum.any?(resource_actions) || assigns.live_resource.can?(assigns, :new, nil))
   end
 
   defp index_item_actions(item_actions) do
@@ -729,7 +729,7 @@ defmodule Backpex.HTML.Resource do
 
   defp action_disabled?(assigns, action_key, items) do
     Enum.filter(items, fn item ->
-      LiveResource.can?(assigns, action_key, item, assigns.live_resource)
+      assigns.live_resource.can?(assigns, action_key, item)
     end)
     |> Enum.empty?()
   end
@@ -758,7 +758,7 @@ defmodule Backpex.HTML.Resource do
       |> assign(:search_active?, get_in(assigns, [:query_options, :search]) not in [nil, ""])
       |> assign(:filter_active?, get_in(assigns, [:query_options, :filters]) != %{})
       |> assign(:title, Backpex.translate({"No %{resources} found", %{resources: assigns.plural_name}}))
-      |> assign(:create_allowed, LiveResource.can?(assigns, :new, nil, assigns.live_resource))
+      |> assign(:create_allowed, assigns.live_resource.can?(assigns, :new, nil))
 
     ~H"""
     <div class="flex justify-center py-16">

--- a/lib/backpex/html/resource.ex
+++ b/lib/backpex/html/resource.ex
@@ -626,10 +626,7 @@ defmodule Backpex.HTML.Resource do
   def resource_buttons(assigns) do
     ~H"""
     <div class="mb-4 flex space-x-2">
-      <.link
-        :if={@live_resource.can?(assigns, :new, nil)}
-        patch={Router.get_path(@socket, @live_resource, @params, :new)}
-      >
+      <.link :if={@live_resource.can?(assigns, :new, nil)} patch={Router.get_path(@socket, @live_resource, @params, :new)}>
         <button class="btn btn-sm btn-outline btn-primary">
           <%= @create_button_label %>
         </button>

--- a/lib/backpex/html/resource.ex
+++ b/lib/backpex/html/resource.ex
@@ -687,7 +687,7 @@ defmodule Backpex.HTML.Resource do
       <.index_filter
         live_resource={@live_resource}
         filter_options={LiveResource.get_filter_options(@query_options)}
-        filters={LiveResource.get_active_filters(@live_resource, assigns)}
+        filters={LiveResource.active_filters(assigns)}
       />
     </div>
     """

--- a/lib/backpex/html/resource.ex
+++ b/lib/backpex/html/resource.ex
@@ -686,7 +686,7 @@ defmodule Backpex.HTML.Resource do
       />
       <.index_filter
         live_resource={@live_resource}
-        filter_options={LiveResource.get_filter_options(@live_resource, @query_options)}
+        filter_options={LiveResource.get_filter_options(@query_options)}
         filters={LiveResource.get_active_filters(@live_resource, assigns)}
       />
     </div>

--- a/lib/backpex/html/resource.ex
+++ b/lib/backpex/html/resource.ex
@@ -703,7 +703,7 @@ defmodule Backpex.HTML.Resource do
 
   defp resource_actions(assigns, resource_actions) do
     Enum.filter(resource_actions, fn {key, _action} ->
-      assigns.live_resource.can?(assigns, key, nil, assigns)
+      assigns.live_resource.can?(assigns, key, nil)
     end)
   end
 

--- a/lib/backpex/html/resource/resource_index_table.html.heex
+++ b/lib/backpex/html/resource/resource_index_table.html.heex
@@ -111,7 +111,7 @@
         >
           <div
             :for={{key, action} <- row_item_actions(@item_actions)}
-            :if={LiveResource.can?(assigns, key, item, @live_resource)}
+            :if={@live_resource.can?(assigns, key, item)}
             class="tooltip hover:z-30"
             data-tip={action.module.label(assigns, item)}
           >

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -9,7 +9,6 @@ defmodule Backpex.FormComponent do
   import Backpex.HTML.Resource
 
   alias Backpex.Fields.Upload
-  alias Backpex.LiveResource
   alias Backpex.Resource
   alias Backpex.ResourceAction
 

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -350,7 +350,7 @@ defmodule Backpex.FormComponent do
       {:ok, data} ->
         selected_items =
           Enum.filter(selected_items, fn item ->
-            LiveResource.can?(socket.assigns, action_key, item, socket.assigns.live_resource)
+            live_resource.can?(socket.assigns, action_key, item)
           end)
 
         {message, socket} =

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -1182,18 +1182,20 @@ defmodule Backpex.LiveResource do
     |> maybe_assign_metrics()
   end
 
-  defp update_item(socket, %{id: id} = _item) do
+  defp update_item(socket, item) do
     %{
       live_resource: live_resource,
       live_action: live_action
     } = socket.assigns
 
-    item = Resource.get(id, socket.assigns, live_resource)
+    item_primary_value = primary_value(socket, item)
+    item = Resource.get(item_primary_value, socket.assigns, live_resource)
 
     socket =
       cond do
         live_action in [:index, :resource_action] and item ->
-          items = Enum.map(socket.assigns.items, &if(primary_value(socket, &1) == id, do: item, else: &1))
+          items =
+            Enum.map(socket.assigns.items, &if(primary_value(socket, &1) == item_primary_value, do: item, else: &1))
 
           assign(socket, :items, items)
 

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -221,11 +221,6 @@ defmodule Backpex.LiveResource do
   @callback resource_created_message() :: binary()
 
   @doc """
-  Returns the schema of the live resource.
-  """
-  @callback schema() :: module()
-
-  @doc """
   Uses LiveResource in the current module to make it a LiveResource.
 
       use Backpex.LiveResource,
@@ -300,9 +295,6 @@ defmodule Backpex.LiveResource do
 
       @impl Backpex.LiveResource
       def create_button_label, do: Backpex.translate({"New %{resource}", %{resource: singular_name()}})
-
-      @impl Backpex.LiveResource
-      def schema, do: @resource_opts[:adapter_config][:schema]
 
       @impl Backpex.LiveResource
       def resource_created_message,

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -514,22 +514,14 @@ defmodule Backpex.LiveResource do
 
   defp field_active?(name, saved_fields) do
     case Map.get(saved_fields, Atom.to_string(name)) do
-      "true" ->
-        true
-
-      "false" ->
-        false
-
-      _other ->
-        true
+      "true" -> true
+      "false" -> false
+      _other -> true
     end
   end
 
   def assign_items(socket) do
-    %{
-      live_resource: live_resource,
-      fields: fields
-    } = socket.assigns
+    %{live_resource: live_resource, fields: fields} = socket.assigns
 
     criteria = build_criteria(socket.assigns)
     items = Resource.list(fields, socket.assigns, live_resource, criteria)
@@ -586,7 +578,7 @@ defmodule Backpex.LiveResource do
   end
 
   @impl Phoenix.LiveView
-  def render(%{live_action: action} = assigns) when action in [:show, :show_edit] do
+  def render(%{live_action: action} = assigns) when action in [:show] do
     resource_show(assigns)
   end
 
@@ -619,16 +611,13 @@ defmodule Backpex.LiveResource do
   end
 
   defp apply_action(socket, :edit) do
-    %{
-      live_resource: live_resource,
-      singular_name: singular_name
-    } = socket.assigns
+    %{live_resource: live_resource, singular_name: singular_name} = socket.assigns
 
     fields = live_resource.fields |> filtered_fields_by_action(socket.assigns, :edit)
     primary_value = URI.decode(socket.assigns.params["backpex_id"])
     item = Resource.get!(primary_value, socket.assigns, live_resource)
 
-    unless live_resource.can?(socket.assigns, :edit, item), do: raise(Backpex.ForbiddenError)
+    if not live_resource.can?(socket.assigns, :edit, item), do: raise(Backpex.ForbiddenError)
 
     socket
     |> assign(:fields, fields)
@@ -639,16 +628,13 @@ defmodule Backpex.LiveResource do
   end
 
   defp apply_action(socket, :show) do
-    %{
-      live_resource: live_resource,
-      singular_name: singular_name
-    } = socket.assigns
+    %{live_resource: live_resource, singular_name: singular_name} = socket.assigns
 
     fields = live_resource.fields() |> filtered_fields_by_action(socket.assigns, :show)
     primary_value = URI.decode(socket.assigns.params["backpex_id"])
     item = Resource.get!(primary_value, socket.assigns, live_resource)
 
-    unless live_resource.can?(socket.assigns, :show, item), do: raise(Backpex.ForbiddenError)
+    if not live_resource.can?(socket.assigns, :show, item), do: raise(Backpex.ForbiddenError)
 
     socket
     |> assign(:page_title, singular_name)
@@ -658,13 +644,9 @@ defmodule Backpex.LiveResource do
   end
 
   defp apply_action(socket, :new) do
-    %{
-      live_resource: live_resource,
-      schema: schema,
-      create_button_label: create_button_label
-    } = socket.assigns
+    %{live_resource: live_resource, schema: schema, create_button_label: create_button_label} = socket.assigns
 
-    unless live_resource.can?(socket.assigns, :new, nil), do: raise(Backpex.ForbiddenError)
+    if not live_resource.can?(socket.assigns, :new, nil), do: raise(Backpex.ForbiddenError)
 
     fields = live_resource.fields() |> filtered_fields_by_action(socket.assigns, :new)
     empty_item = schema.__struct__()
@@ -687,7 +669,7 @@ defmodule Backpex.LiveResource do
 
     action = live_resource.resource_actions()[id]
 
-    unless live_resource.can?(socket.assigns, id, nil), do: raise(Backpex.ForbiddenError)
+    if not live_resource.can?(socket.assigns, id, nil), do: raise(Backpex.ForbiddenError)
 
     socket
     |> assign(:page_title, ResourceAction.name(action, :title))
@@ -730,7 +712,7 @@ defmodule Backpex.LiveResource do
       params: params
     } = socket.assigns
 
-    unless live_resource.can?(socket.assigns, :index, nil), do: raise(Backpex.ForbiddenError)
+    if not live_resource.can?(socket.assigns, :index, nil), do: raise(Backpex.ForbiddenError)
 
     fields = live_resource.fields() |> filtered_fields_by_action(socket.assigns, :index)
 
@@ -788,11 +770,7 @@ defmodule Backpex.LiveResource do
   end
 
   defp assign_changeset(socket, fields) do
-    %{
-      item: item,
-      changeset_function: changeset_function,
-      live_action: live_action
-    } = socket.assigns
+    %{item: item, changeset_function: changeset_function, live_action: live_action} = socket.assigns
 
     metadata = Resource.build_changeset_metadata(socket.assigns)
     changeset = changeset_function.(item, default_attrs(live_action, fields, socket.assigns), metadata)
@@ -830,12 +808,7 @@ defmodule Backpex.LiveResource do
   defp default_attrs(_live_action, _fields, _assigns), do: %{}
 
   defp maybe_redirect_to_default_filters(%{assigns: %{filters_changed: false}} = socket) do
-    %{
-      live_resource: live_resource,
-      query_options: query_options,
-      params: params,
-      filters: filters
-    } = socket.assigns
+    %{live_resource: live_resource, query_options: query_options, params: params, filters: filters} = socket.assigns
 
     filters_with_defaults =
       filters
@@ -1168,10 +1141,7 @@ defmodule Backpex.LiveResource do
   end
 
   defp update_item(socket, item) do
-    %{
-      live_resource: live_resource,
-      live_action: live_action
-    } = socket.assigns
+    %{live_resource: live_resource, live_action: live_action} = socket.assigns
 
     item_primary_value = primary_value(socket, item)
     item = Resource.get(item_primary_value, socket.assigns, live_resource)

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -1224,11 +1224,11 @@ defmodule Backpex.LiveResource do
 
   ## Examples
 
-      iex> Backpex.LiveResource.order_options_by_params(%{"order_by" => "field", "order_direction" => "asc"}, [field: %{}], %{by: :id, direction: :asc}, %{}, [:asc, :desc])
+      iex> Backpex.LiveResource.order_options_by_params(%{"order_by" => "field", "order_direction" => "asc"}, [field: %{}], %{by: :id, direction: :asc}, %{})
       %{order_by: :field, order_direction: :asc}
-      iex> Backpex.LiveResource.order_options_by_params(%{}, [field: %{}], %{by: :id, direction: :desc}, %{}, [:asc, :desc])
+      iex> Backpex.LiveResource.order_options_by_params(%{}, [field: %{}], %{by: :id, direction: :desc}, %{})
       %{order_by: :id, order_direction: :desc}
-      iex> Backpex.LiveResource.order_options_by_params(%{"order_by" => "field", "order_direction" => "asc"}, [field: %{orderable: false}], %{by: :id, direction: :asc}, %{}, [:asc, :desc])
+      iex> Backpex.LiveResource.order_options_by_params(%{"order_by" => "field", "order_direction" => "asc"}, [field: %{orderable: false}], %{by: :id, direction: :asc}, %{})
       %{order_by: :id, order_direction: :asc}
   """
   def order_options_by_params(params, fields, init_order, assigns) do

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -260,44 +260,22 @@ defmodule Backpex.LiveResource do
 
       alias Backpex.LiveResource
 
-      def config(key) do
-        Keyword.fetch!(@resource_opts, key)
-      end
+      def config(key), do: Keyword.fetch!(@resource_opts, key)
 
       @impl Phoenix.LiveView
-      def mount(params, session, socket) do
-        LiveResource.mount(params, session, socket)
-      end
+      def mount(params, session, socket), do: LiveResource.mount(params, session, socket)
 
       @impl Phoenix.LiveView
-      def handle_params(params, url, socket) do
-        LiveResource.handle_params(params, url, socket)
-      end
+      def handle_params(params, url, socket), do: LiveResource.handle_params(params, url, socket)
 
       @impl Phoenix.LiveView
-      def handle_event(event, params, socket) do
-        LiveResource.handle_event(event, params, socket)
-      end
+      def handle_event(event, params, socket), do: LiveResource.handle_event(event, params, socket)
 
       @impl Phoenix.LiveView
-      def handle_info(msg, socket) do
-        LiveResource.handle_info(msg, socket)
-      end
+      def handle_info(msg, socket), do: LiveResource.handle_info(msg, socket)
 
       @impl Phoenix.LiveView
-      def render(%{live_action: action} = assigns) when action in [:show, :show_edit] do
-        resource_show(assigns)
-      end
-
-      @impl Phoenix.LiveView
-      def render(%{live_action: action} = assigns) when action in [:new, :edit] do
-        resource_form(assigns)
-      end
-
-      @impl Phoenix.LiveView
-      def render(assigns) do
-        resource_index(assigns)
-      end
+      def render(assigns), do: LiveResource.render(assigns)
 
       @impl Backpex.LiveResource
       def can?(_assigns, _action, _item), do: true
@@ -613,6 +591,21 @@ defmodule Backpex.LiveResource do
 
     socket
     |> assign(metrics: metrics)
+  end
+
+  @impl Phoenix.LiveView
+  def render(%{live_action: action} = assigns) when action in [:show, :show_edit] do
+    resource_show(assigns)
+  end
+
+  @impl Phoenix.LiveView
+  def render(%{live_action: action} = assigns) when action in [:new, :edit] do
+    resource_form(assigns)
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    resource_index(assigns)
   end
 
   @impl Phoenix.LiveView

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -156,8 +156,7 @@ defmodule Backpex.LiveResource do
 
   The function has to return an `Ecto.Query`. It is recommended to build your `item_query` on top of the incoming query. Otherwise you will likely get binding errors.
   """
-  @callback item_query(query :: Ecto.Query.t(), live_action :: atom(), assigns :: map()) ::
-              Ecto.Query.t()
+  @callback item_query(query :: Ecto.Query.t(), live_action :: atom(), assigns :: map()) :: Ecto.Query.t()
 
   @doc """
   The function that can be used to add content to certain positions on Backpex views. It may also be used to overwrite content.
@@ -1625,7 +1624,7 @@ defmodule Backpex.LiveResource do
   @doc """
   Returns list of filter options from query options
   """
-  def get_filter_options(module, query_options) do
+  def get_filter_options(query_options) do
     query_options
     |> Map.get(:filters, %{})
     |> Map.drop([Atom.to_string(get_empty_filter_key())])

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -611,14 +611,14 @@ defmodule Backpex.LiveResource do
     {:noreply, socket}
   end
 
-  def apply_action(socket, :index) do
+  defp apply_action(socket, :index) do
     socket
     |> assign(:page_title, socket.assigns.plural_name)
     |> apply_index()
     |> assign(:item, nil)
   end
 
-  def apply_action(socket, :edit) do
+  defp apply_action(socket, :edit) do
     %{
       live_resource: live_resource,
       singular_name: singular_name
@@ -638,7 +638,7 @@ defmodule Backpex.LiveResource do
     |> assign_changeset(fields)
   end
 
-  def apply_action(socket, :show) do
+  defp apply_action(socket, :show) do
     %{
       live_resource: live_resource,
       singular_name: singular_name
@@ -657,7 +657,7 @@ defmodule Backpex.LiveResource do
     |> apply_show_return_to(item)
   end
 
-  def apply_action(socket, :new) do
+  defp apply_action(socket, :new) do
     %{
       live_resource: live_resource,
       schema: schema,
@@ -677,7 +677,7 @@ defmodule Backpex.LiveResource do
     |> assign_changeset(fields)
   end
 
-  def apply_action(socket, :resource_action) do
+  defp apply_action(socket, :resource_action) do
     %{live_resource: live_resource} = socket.assigns
 
     id =
@@ -699,12 +699,12 @@ defmodule Backpex.LiveResource do
     |> assign_changeset(action.module.fields())
   end
 
-  def apply_item_actions(socket, action) when action in [:index, :resource_action] do
+  defp apply_item_actions(socket, action) when action in [:index, :resource_action] do
     item_actions = socket.assigns.live_resource.item_actions(default_item_actions())
     assign(socket, :item_actions, item_actions)
   end
 
-  def apply_item_actions(socket, _action), do: socket
+  defp apply_item_actions(socket, _action), do: socket
 
   defp apply_index_return_to(socket) do
     %{live_resource: live_resource, params: params, query_options: query_options} = socket.assigns
@@ -1404,10 +1404,7 @@ defmodule Backpex.LiveResource do
   def orderable?(field) when is_nil(field), do: false
   def orderable?({_name, field_options}), do: Map.get(field_options, :orderable, true)
 
-  @doc """
-  TODO: make private?
-  """
-  def build_criteria(assigns) do
+  defp build_criteria(assigns) do
     %{
       schema: schema,
       fields: fields,
@@ -1576,7 +1573,7 @@ defmodule Backpex.LiveResource do
     if value in permitted, do: value, else: default
   end
 
-  def default_item_actions do
+  defp default_item_actions do
     [
       show: %{
         module: Backpex.ItemActions.Show,
@@ -1593,11 +1590,11 @@ defmodule Backpex.LiveResource do
     ]
   end
 
-  def maybe_put_empty_filter(%{} = filters, empty_filter_key) when filters == %{} do
+  defp maybe_put_empty_filter(%{} = filters, empty_filter_key) when filters == %{} do
     Map.put(filters, Atom.to_string(empty_filter_key), true)
   end
 
-  def maybe_put_empty_filter(filters, _empty_filter_key) do
+  defp maybe_put_empty_filter(filters, _empty_filter_key) do
     filters
   end
 
@@ -1621,7 +1618,7 @@ defmodule Backpex.LiveResource do
     end)
   end
 
-  def get_valid_filters_from_params(%{"filters" => filters} = params, valid_filters, empty_filter_key) do
+  defp get_valid_filters_from_params(%{"filters" => filters} = params, valid_filters, empty_filter_key) do
     valid_filters = Keyword.put(valid_filters, empty_filter_key, %{})
 
     filters =
@@ -1641,7 +1638,7 @@ defmodule Backpex.LiveResource do
     Map.put(params, "filters", filters)
   end
 
-  def get_valid_filters_from_params(_params, _valid_filters, _empty_filter_key), do: %{}
+  defp get_valid_filters_from_params(_params, _valid_filters, _empty_filter_key), do: %{}
 
   defp maybe_to_atom(nil), do: nil
   defp maybe_to_atom(value), do: String.to_existing_atom(value)

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -14,8 +14,6 @@ defmodule Backpex.LiveResource do
   alias Backpex.ResourceAction
   alias Backpex.Router
 
-  @empty_filter_key :empty_filter
-
   @permitted_order_directions ~w(asc desc)a
 
   @options_schema [
@@ -721,7 +719,7 @@ defmodule Backpex.LiveResource do
     init_order = live_resource.config(:init_order)
 
     filters = active_filters(socket.assigns)
-    valid_filter_params = get_valid_filters_from_params(params, filters, @empty_filter_key)
+    valid_filter_params = get_valid_filters_from_params(params, filters, empty_filter_key())
 
     count_criteria = [
       search: search_options(params, fields, schema),
@@ -917,7 +915,7 @@ defmodule Backpex.LiveResource do
   def handle_event("change-filter", params, socket) do
     query_options = socket.assigns.query_options
 
-    empty_filter_name = Atom.to_string(@empty_filter_key)
+    empty_filter_name = Atom.to_string(empty_filter_key())
 
     filters =
       Map.get(query_options, :filters, %{})
@@ -957,7 +955,7 @@ defmodule Backpex.LiveResource do
         :filters,
         Map.get(query_options, :filters, %{})
         |> Map.delete(field)
-        |> maybe_put_empty_filter(@empty_filter_key)
+        |> maybe_put_empty_filter(empty_filter_key())
       )
 
     to = Router.get_path(socket, live_resource, params, :index, new_query_options)
@@ -986,7 +984,7 @@ defmodule Backpex.LiveResource do
     filters =
       Map.get(query_options, :filters, %{})
       |> Map.put(field, get_preset_values.())
-      |> Map.drop([Atom.to_string(@empty_filter_key)])
+      |> Map.drop([Atom.to_string(empty_filter_key())])
 
     to =
       Router.get_path(
@@ -1120,7 +1118,7 @@ defmodule Backpex.LiveResource do
     } = socket.assigns
 
     filters = active_filters(socket.assigns)
-    valid_filter_params = get_valid_filters_from_params(params, filters, @empty_filter_key)
+    valid_filter_params = get_valid_filters_from_params(params, filters, empty_filter_key())
 
     count_criteria = [
       search: search_options(params, fields, schema),
@@ -1355,7 +1353,7 @@ defmodule Backpex.LiveResource do
 
   def filter_options(_no_filters_present, _filter_configs), do: %{}
 
-  def get_empty_filter_key, do: @empty_filter_key
+  def empty_filter_key, do: :empty_filter
 
   @doc """
   Checks whether a field is orderable or not.
@@ -1574,7 +1572,7 @@ defmodule Backpex.LiveResource do
   def get_filter_options(query_options) do
     query_options
     |> Map.get(:filters, %{})
-    |> Map.drop([Atom.to_string(get_empty_filter_key())])
+    |> Map.drop([Atom.to_string(empty_filter_key())])
   end
 
   @doc """
@@ -1584,7 +1582,7 @@ defmodule Backpex.LiveResource do
     filters = assigns.live_resource.filters(assigns)
 
     Enum.filter(filters, fn {key, option} ->
-      get_empty_filter_key() != key and option.module.can?(assigns)
+      empty_filter_key() != key and option.module.can?(assigns)
     end)
   end
 

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -1255,7 +1255,7 @@ defmodule Backpex.LiveResource do
     %{order_by: order_by, order_direction: order_direction}
   end
 
-  defp permitted_order_directions(), do: ~w(asc desc)a
+  defp permitted_order_directions, do: ~w(asc desc)a
 
   @doc """
   Returns all orderable fields. A field is orderable by default.

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -586,7 +586,7 @@ defmodule Backpex.LiveResource do
         } = assigns
     } = socket
 
-    filters = get_active_filters(live_resource, assigns)
+    filters = active_filters(assigns)
 
     metrics =
       socket.assigns.live_resource.metrics()
@@ -756,7 +756,7 @@ defmodule Backpex.LiveResource do
     per_page_default = live_resource.config(:per_page_default)
     init_order = live_resource.config(:init_order)
 
-    filters = get_active_filters(live_resource, socket.assigns)
+    filters = active_filters(socket.assigns)
     valid_filter_params = get_valid_filters_from_params(params, filters, @empty_filter_key)
 
     count_criteria = [
@@ -1162,7 +1162,7 @@ defmodule Backpex.LiveResource do
       query_options: query_options
     } = socket.assigns
 
-    filters = get_active_filters(live_resource, socket.assigns)
+    filters = active_filters(socket.assigns)
     valid_filter_params = get_valid_filters_from_params(params, filters, @empty_filter_key)
 
     count_criteria = [
@@ -1633,8 +1633,8 @@ defmodule Backpex.LiveResource do
   @doc """
   Returns list of active filters.
   """
-  def get_active_filters(module, assigns) do
-    filters = module.filters(assigns)
+  def active_filters(assigns) do
+    filters = assigns.live_resource.filters(assigns)
 
     Enum.filter(filters, fn {key, option} ->
       get_empty_filter_key() != key and option.module.can?(assigns)

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -14,8 +14,6 @@ defmodule Backpex.LiveResource do
   alias Backpex.ResourceAction
   alias Backpex.Router
 
-  @permitted_order_directions ~w(asc desc)a
-
   @options_schema [
     adapter: [
       doc: "The data layer adapter to use.",
@@ -738,7 +736,7 @@ defmodule Backpex.LiveResource do
 
     page_options = %{page: page, per_page: per_page}
 
-    order_options = order_options_by_params(params, fields, init_order, socket.assigns, @permitted_order_directions)
+    order_options = order_options_by_params(params, fields, init_order, socket.assigns)
 
     query_options =
       page_options
@@ -1233,7 +1231,7 @@ defmodule Backpex.LiveResource do
       iex> Backpex.LiveResource.order_options_by_params(%{"order_by" => "field", "order_direction" => "asc"}, [field: %{orderable: false}], %{by: :id, direction: :asc}, %{}, [:asc, :desc])
       %{order_by: :id, order_direction: :asc}
   """
-  def order_options_by_params(params, fields, init_order, assigns, permitted_order_directions) do
+  def order_options_by_params(params, fields, init_order, assigns) do
     init_order = resolve_init_order(init_order, assigns)
 
     order_by =
@@ -1250,12 +1248,14 @@ defmodule Backpex.LiveResource do
       |> Map.get("order_direction")
       |> maybe_to_atom()
       |> value_in_permitted_or_default(
-        permitted_order_directions,
+        permitted_order_directions(),
         Map.get(init_order, :direction)
       )
 
     %{order_by: order_by, order_direction: order_direction}
   end
+
+  defp permitted_order_directions(), do: ~w(asc desc)a
 
   @doc """
   Returns all orderable fields. A field is orderable by default.

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -586,7 +586,7 @@ defmodule Backpex.LiveResource do
         } = assigns
     } = socket
 
-    filters = Backpex.LiveResource.get_active_filters(live_resource, assigns)
+    filters = get_active_filters(live_resource, assigns)
 
     metrics =
       socket.assigns.live_resource.metrics()
@@ -756,8 +756,8 @@ defmodule Backpex.LiveResource do
     per_page_default = live_resource.config(:per_page_default)
     init_order = live_resource.config(:init_order)
 
-    filters = Backpex.LiveResource.get_active_filters(live_resource, socket.assigns)
-    valid_filter_params = Backpex.LiveResource.get_valid_filters_from_params(params, filters, @empty_filter_key)
+    filters = get_active_filters(live_resource, socket.assigns)
+    valid_filter_params = get_valid_filters_from_params(params, filters, @empty_filter_key)
 
     count_criteria = [
       search: search_options(params, fields, schema),
@@ -1002,7 +1002,7 @@ defmodule Backpex.LiveResource do
         :filters,
         Map.get(query_options, :filters, %{})
         |> Map.delete(field)
-        |> Backpex.LiveResource.maybe_put_empty_filter(@empty_filter_key)
+        |> maybe_put_empty_filter(@empty_filter_key)
       )
 
     to = Router.get_path(socket, live_resource, params, :index, new_query_options)
@@ -1162,8 +1162,8 @@ defmodule Backpex.LiveResource do
       query_options: query_options
     } = socket.assigns
 
-    filters = Backpex.LiveResource.get_active_filters(live_resource, socket.assigns)
-    valid_filter_params = Backpex.LiveResource.get_valid_filters_from_params(params, filters, @empty_filter_key)
+    filters = get_active_filters(live_resource, socket.assigns)
+    valid_filter_params = get_valid_filters_from_params(params, filters, @empty_filter_key)
 
     count_criteria = [
       search: search_options(params, fields, schema),


### PR DESCRIPTION
see https://hexdocs.pm/credo/Credo.Check.Refactor.LongQuoteBlocks.html

- move everything from quote block to top level module in `Backpex.LiveResource`
- change some internal function to private; see f7f124b3edaa2e657ef7d296d158ac8c75878949
- remove `Backpex.LiveResource.schema/0` function; see 709bff8dac65ec135d6328d79fcd1c7ffb3ab8ef
- fix live updates for non-id primary keys; see dc051d2815bd364b32e43c2c296d4ee37eb03157
- remove obsolete `Backpex.LiveResource.can?/4` helper; see 9bdd735533a69ea51401bc7c2b8282acca949e7d and a4742105a06155e8d8da84d7084ff817ca2b5f16
- simplify active filters function; see 2aad9baa0d708e9d6bf93d3d7d9c09739dfcd7cd
- simplify `get_filter_options` function; see 2a43e79ea9e082272c731b592c739838452b4321