### PR TITLE
Fix error when submitting short link with existing url suffix

### DIFF
--- a/demo/lib/demo/short_link.ex
+++ b/demo/lib/demo/short_link.ex
@@ -32,7 +32,7 @@ defmodule Demo.ShortLink do
       message: "must be URL safe (only letters, numbers, underscores, and hyphens)"
     )
     |> validate_length(:short_key, min: 1, max: 64)
-    |> unique_constraint(:short_key)
+    |> unique_constraint(:short_key, name: :short_links_pkey)
   end
 
   defp add_short_key(changeset) do

--- a/demo/priv/repo/migrations/20241112092150_drop_short_links_unique_index.exs
+++ b/demo/priv/repo/migrations/20241112092150_drop_short_links_unique_index.exs
@@ -1,0 +1,7 @@
+defmodule Demo.Repo.Migrations.DropShortLinksUniqueIndex do
+  use Ecto.Migration
+
+  def change do
+    drop index(:short_links, [:short_key])
+  end
+end


### PR DESCRIPTION
Currently, there is an error when submitting a short link with a URL suffix that already exists.

- Check for pkey unqiue constraint in changeset function
- Drop unique index as this is already covered by the pkey index