### PR TITLE
Add ‘rows' attribute to the textarea, with a default value of 2 rows.

### DIFF
--- a/demo/lib/demo_web/live/post_live.ex
+++ b/demo/lib/demo_web/live/post_live.ex
@@ -111,6 +111,7 @@ defmodule DemoWeb.PostLive do
       body: %{
         module: Backpex.Fields.Textarea,
         label: "Body",
+        rows: 10,
         except: [:index]
       },
       published: %{

--- a/lib/backpex/fields/textarea.ex
+++ b/lib/backpex/fields/textarea.ex
@@ -34,7 +34,7 @@ defmodule Backpex.Fields.Textarea do
         <BackpexForm.input
           type="textarea"
           field={@form[@name]}
-          rows={@field_options[:rows] || 3}
+          rows={@field_options[:rows] || 2}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}

--- a/lib/backpex/fields/textarea.ex
+++ b/lib/backpex/fields/textarea.ex
@@ -34,6 +34,7 @@ defmodule Backpex.Fields.Textarea do
         <BackpexForm.input
           type="textarea"
           field={@form[@name]}
+          rows={@field_options[:rows] || 3}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}


### PR DESCRIPTION
Add ‘rows' attribute to the textarea, with a default value of 3 rows.