### PR TITLE
Rename item and resource action `init_change/1` callback to `base_schema/1`

### DIFF
--- a/demo/lib/demo_web/item_actions/duplicate_tag.ex
+++ b/demo/lib/demo_web/item_actions/duplicate_tag.ex
@@ -46,7 +46,7 @@ defmodule DemoWeb.ItemActions.DuplicateTag do
   end
 
   @impl Backpex.ItemAction
-  def init_change(assigns) do
+  def base_schema(assigns) do
     [item | _other] = assigns.selected_items
 
     item

--- a/demo/lib/demo_web/item_actions/duplicate_tag.ex
+++ b/demo/lib/demo_web/item_actions/duplicate_tag.ex
@@ -46,7 +46,7 @@ defmodule DemoWeb.ItemActions.DuplicateTag do
   end
 
   @impl Backpex.ItemAction
-  def base_schema(assigns) do
+  def base_item(assigns) do
     [item | _other] = assigns.selected_items
 
     item

--- a/demo/lib/demo_web/item_actions/duplicate_tag.ex
+++ b/demo/lib/demo_web/item_actions/duplicate_tag.ex
@@ -46,7 +46,7 @@ defmodule DemoWeb.ItemActions.DuplicateTag do
   end
 
   @impl Backpex.ItemAction
-  def base_item(assigns) do
+  def base_schema(assigns) do
     [item | _other] = assigns.selected_items
 
     item

--- a/guides/upgrading/v0.9.md
+++ b/guides/upgrading/v0.9.md
@@ -73,4 +73,4 @@ check the updated function definitions in the module documentation.
 
 ## Resource Action ad Item Action `init_change/1` is renamed
 
-The term `init_change` was confusing because the result is being used as the base schema / item for the changeset function. Therefore we renamed the function to `base_item/1` for both Item Actions and Resource Actions.
+The term `init_change` was confusing because the result is being used as the base schema / item for the changeset function. Therefore we renamed the function to `base_schema/1` for both Item Actions and Resource Actions.

--- a/guides/upgrading/v0.9.md
+++ b/guides/upgrading/v0.9.md
@@ -70,3 +70,8 @@ end
 
 Although the change is relatively small, if you are using public functions of the `Backpex.LiveResource` directly,
 check the updated function definitions in the module documentation.
+
+## Item Action `init_change/1` is renamed
+
+The term `init_change` was confusing because the result is being used as the base schema / item for the changeset function.
+Therefore we renamed the function to `base_schema/1`.

--- a/guides/upgrading/v0.9.md
+++ b/guides/upgrading/v0.9.md
@@ -71,7 +71,6 @@ end
 Although the change is relatively small, if you are using public functions of the `Backpex.LiveResource` directly,
 check the updated function definitions in the module documentation.
 
-## Item Action `init_change/1` is renamed
+## Resource Action ad Item Action `init_change/1` is renamed
 
-The term `init_change` was confusing because the result is being used as the base schema / item for the changeset function.
-Therefore we renamed the function to `base_schema/1`.
+The term `init_change` was confusing because the result is being used as the base schema / item for the changeset function. Therefore we renamed the function to `base_schema/1` for both Item Actions and Resource Actions.

--- a/guides/upgrading/v0.9.md
+++ b/guides/upgrading/v0.9.md
@@ -73,4 +73,4 @@ check the updated function definitions in the module documentation.
 
 ## Resource Action ad Item Action `init_change/1` is renamed
 
-The term `init_change` was confusing because the result is being used as the base schema / item for the changeset function. Therefore we renamed the function to `base_schema/1` for both Item Actions and Resource Actions.
+The term `init_change` was confusing because the result is being used as the base schema / item for the changeset function. Therefore we renamed the function to `base_item/1` for both Item Actions and Resource Actions.

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -22,12 +22,13 @@ defmodule Backpex.ItemAction do
   @callback fields() :: list()
 
   @doc """
-  Initial change. The result will be passed to `c:changeset/3` in order to generate a changeset.
+  The base schema to use for the changeset. The result will be passed as the first parameter to `c:changeset/3' each time it is called.
 
-  This function is optional and can be used to use changesets with schemas in item actions. If this function
-  is not provided a changeset will be generated automatically based on the provided types in `c:fields/0`.
+
+  This function is optional and can be used to use changesets with schemas in item actions. If this function is not provided,
+  a schemaless changeset will be created with the provided types from `c:fields/0`.
   """
-  @callback init_change(assigns :: map()) ::
+  @callback base_schema(assigns :: map()) ::
               Ecto.Schema.t()
               | Ecto.Changeset.t()
               | {Ecto.Changeset.data(), Ecto.Changeset.types()}
@@ -105,12 +106,13 @@ defmodule Backpex.ItemAction do
       def changeset(_change, _attrs, metadata) do
         assigns = Keyword.get(metadata, :assigns)
 
-        init_change(assigns)
+        assigns
+        |> base_schema()
         |> Ecto.Changeset.change()
       end
 
       @impl Backpex.ItemAction
-      def init_change(_assigns) do
+      def base_schema(_assigns) do
         types = Backpex.Field.changeset_types(fields())
 
         {%{}, types}

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -22,7 +22,7 @@ defmodule Backpex.ItemAction do
   @callback fields() :: list()
 
   @doc """
-  The base schema to use for the changeset. The result will be passed as the first parameter to `c:changeset/3' each time it is called.
+  The base schema to use for the changeset. The result will be passed as the first parameter to `c:changeset/3` each time it is called.
 
 
   This function is optional and can be used to use changesets with schemas in item actions. If this function is not provided,

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -28,7 +28,7 @@ defmodule Backpex.ItemAction do
   This function is optional and can be used to use changesets with schemas in item actions. If this function is not provided,
   a schemaless changeset will be created with the provided types from `c:fields/0`.
   """
-  @callback base_schema(assigns :: map()) ::
+  @callback base_item(assigns :: map()) ::
               Ecto.Schema.t()
               | Ecto.Changeset.t()
               | {Ecto.Changeset.data(), Ecto.Changeset.types()}
@@ -107,12 +107,12 @@ defmodule Backpex.ItemAction do
         assigns = Keyword.get(metadata, :assigns)
 
         assigns
-        |> base_schema()
+        |> base_item()
         |> Ecto.Changeset.change()
       end
 
       @impl Backpex.ItemAction
-      def base_schema(_assigns) do
+      def base_item(_assigns) do
         types = Backpex.Field.changeset_types(fields())
 
         {%{}, types}

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -22,7 +22,7 @@ defmodule Backpex.ItemAction do
   @callback fields() :: list()
 
   @doc """
-  The base schema to use for the changeset. The result will be passed as the first parameter to `c:changeset/3` each time it is called.
+  The base item / schema to use for the changeset. The result will be passed as the first parameter to `c:changeset/3` each time it is called.
 
 
   This function is optional and can be used to use changesets with schemas in item actions. If this function is not provided,

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -28,7 +28,7 @@ defmodule Backpex.ItemAction do
   This function is optional and can be used to use changesets with schemas in item actions. If this function is not provided,
   a schemaless changeset will be created with the provided types from `c:fields/0`.
   """
-  @callback base_item(assigns :: map()) ::
+  @callback base_schema(assigns :: map()) ::
               Ecto.Schema.t()
               | Ecto.Changeset.t()
               | {Ecto.Changeset.data(), Ecto.Changeset.types()}
@@ -107,12 +107,12 @@ defmodule Backpex.ItemAction do
         assigns = Keyword.get(metadata, :assigns)
 
         assigns
-        |> base_item()
+        |> base_schema()
         |> Ecto.Changeset.change()
       end
 
       @impl Backpex.ItemAction
-      def base_item(_assigns) do
+      def base_schema(_assigns) do
         types = Backpex.Field.changeset_types(fields())
 
         {%{}, types}

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -71,8 +71,7 @@ defmodule Backpex.FormComponent do
   end
 
   def handle_event("validate", %{"change" => change, "_target" => target}, %{assigns: %{action_type: :item}} = socket) do
-    %{assigns: %{item_action_base_item: item_action_base_item, live_resource: live_resource, fields: fields} = assigns} =
-      socket
+    %{assigns: %{item: item, live_resource: live_resource, fields: fields} = assigns} = socket
 
     target = Enum.at(target, 1)
 
@@ -81,9 +80,7 @@ defmodule Backpex.FormComponent do
       |> drop_readonly_changes(fields, assigns)
       |> put_upload_change(socket, :validate)
 
-    changeset =
-      item_action_base_item
-      |> Resource.change(change, fields, assigns, live_resource, target: target)
+    changeset = Resource.change(item, change, fields, assigns, live_resource, target: target)
 
     form = Phoenix.Component.to_form(changeset, as: :change)
 
@@ -336,13 +333,13 @@ defmodule Backpex.FormComponent do
           selected_items: selected_items,
           action_to_confirm: action_to_confirm,
           return_to: return_to,
-          item_action_base_item: item_action_base_item,
+          item: item,
           fields: fields
         } = assigns
     } = socket
 
     result =
-      item_action_base_item
+      item
       |> Backpex.Resource.change(params, fields, assigns, live_resource)
       |> Ecto.Changeset.apply_action(:insert)
 

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -71,10 +71,8 @@ defmodule Backpex.FormComponent do
   end
 
   def handle_event("validate", %{"change" => change, "_target" => target}, %{assigns: %{action_type: :item}} = socket) do
-    %{
-      assigns:
-        %{item_action_base_schema: item_action_base_schema, live_resource: live_resource, fields: fields} = assigns
-    } = socket
+    %{assigns: %{item_action_base_item: item_action_base_item, live_resource: live_resource, fields: fields} = assigns} =
+      socket
 
     target = Enum.at(target, 1)
 
@@ -84,7 +82,7 @@ defmodule Backpex.FormComponent do
       |> put_upload_change(socket, :validate)
 
     changeset =
-      item_action_base_schema
+      item_action_base_item
       |> Resource.change(change, fields, assigns, live_resource, target: target)
 
     form = Phoenix.Component.to_form(changeset, as: :change)
@@ -338,13 +336,13 @@ defmodule Backpex.FormComponent do
           selected_items: selected_items,
           action_to_confirm: action_to_confirm,
           return_to: return_to,
-          item_action_base_schema: item_action_base_schema,
+          item_action_base_item: item_action_base_item,
           fields: fields
         } = assigns
     } = socket
 
     result =
-      item_action_base_schema
+      item_action_base_item
       |> Backpex.Resource.change(params, fields, assigns, live_resource)
       |> Ecto.Changeset.apply_action(:insert)
 

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -71,7 +71,10 @@ defmodule Backpex.FormComponent do
   end
 
   def handle_event("validate", %{"change" => change, "_target" => target}, %{assigns: %{action_type: :item}} = socket) do
-    %{assigns: %{item_action_types: item_action_types, live_resource: live_resource, fields: fields} = assigns} = socket
+    %{
+      assigns:
+        %{item_action_base_schema: item_action_base_schema, live_resource: live_resource, fields: fields} = assigns
+    } = socket
 
     target = Enum.at(target, 1)
 
@@ -81,7 +84,7 @@ defmodule Backpex.FormComponent do
       |> put_upload_change(socket, :validate)
 
     changeset =
-      item_action_types
+      item_action_base_schema
       |> Resource.change(change, fields, assigns, live_resource, target: target)
 
     form = Phoenix.Component.to_form(changeset, as: :change)
@@ -335,13 +338,13 @@ defmodule Backpex.FormComponent do
           selected_items: selected_items,
           action_to_confirm: action_to_confirm,
           return_to: return_to,
-          item_action_types: item_action_types,
+          item_action_base_schema: item_action_base_schema,
           fields: fields
         } = assigns
     } = socket
 
     result =
-      item_action_types
+      item_action_base_schema
       |> Backpex.Resource.change(params, fields, assigns, live_resource)
       |> Ecto.Changeset.apply_action(:insert)
 

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -672,7 +672,7 @@ defmodule Backpex.LiveResource do
     if not live_resource.can?(socket.assigns, id, nil), do: raise(Backpex.ForbiddenError)
 
     changeset_function = &action.module.changeset/3
-    item = action.module.base_item(socket.assigns)
+    item = action.module.base_schema(socket.assigns)
 
     socket
     |> assign(:page_title, ResourceAction.name(action, :title))
@@ -1177,17 +1177,17 @@ defmodule Backpex.LiveResource do
   end
 
   defp open_action_confirm_modal(socket, action, key) do
-    base_item = action.module.base_item(socket.assigns)
+    base_schema = action.module.base_schema(socket.assigns)
 
     changeset_function = &action.module.changeset/3
 
     metadata = Resource.build_changeset_metadata(socket.assigns)
 
-    changeset = changeset_function.(base_item, %{}, metadata)
+    changeset = changeset_function.(base_schema, %{}, metadata)
 
     socket =
       socket
-      |> assign(:item, base_item)
+      |> assign(:item, base_schema)
       |> assign(:changeset_function, changeset_function)
       |> assign(:changeset, changeset)
       |> assign(:action_to_confirm, Map.put(action, :key, key))

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -671,7 +671,7 @@ defmodule Backpex.LiveResource do
     |> assign(:page_title, ResourceAction.name(action, :title))
     |> assign(:resource_action, action)
     |> assign(:resource_action_id, id)
-    |> assign(:item, action.module.init_change(socket.assigns))
+    |> assign(:item, action.module.base_item(socket.assigns))
     |> apply_index()
     |> assign(:changeset_function, &action.module.changeset/3)
     |> assign_changeset(action.module.fields())

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -1173,19 +1173,17 @@ defmodule Backpex.LiveResource do
   end
 
   defp open_action_confirm_modal(socket, action, key) do
-    init_change = action.module.init_change(socket.assigns)
+    base_schema = action.module.base_schema(socket.assigns)
+
     changeset_function = &action.module.changeset/3
 
     metadata = Resource.build_changeset_metadata(socket.assigns)
 
-    changeset =
-      init_change
-      |> Ecto.Changeset.change()
-      |> changeset_function.(%{}, metadata)
+    changeset = changeset_function.(base_schema, %{}, metadata)
 
     socket =
       socket
-      |> assign(:item_action_types, init_change)
+      |> assign(:item_action_base_schema, base_schema)
       |> assign(:changeset_function, changeset_function)
       |> assign(:changeset, changeset)
       |> assign(:action_to_confirm, Map.put(action, :key, key))

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -1183,7 +1183,7 @@ defmodule Backpex.LiveResource do
 
     socket =
       socket
-      |> assign(:item_action_base_item, base_item)
+      |> assign(:item, base_item)
       |> assign(:changeset_function, changeset_function)
       |> assign(:changeset, changeset)
       |> assign(:action_to_confirm, Map.put(action, :key, key))

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -622,7 +622,7 @@ defmodule Backpex.LiveResource do
     |> assign(:changeset_function, changeset_function)
     |> assign(:page_title, Backpex.translate({"Edit %{resource}", %{resource: singular_name}}))
     |> assign(:item, item)
-    |> assign_changeset(changeset_function, item, :edit, fields)
+    |> assign_changeset(changeset_function, item, fields, :edit)
   end
 
   defp apply_action(socket, :show) do
@@ -656,7 +656,7 @@ defmodule Backpex.LiveResource do
     |> assign(:page_title, create_button_label)
     |> assign(:fields, fields)
     |> assign(:item, empty_item)
-    |> assign_changeset(changeset_function, empty_item, :new, fields)
+    |> assign_changeset(changeset_function, empty_item, fields, :new)
   end
 
   defp apply_action(socket, :resource_action) do
@@ -681,7 +681,7 @@ defmodule Backpex.LiveResource do
     |> assign(:item, item)
     |> apply_index()
     |> assign(:changeset_function, changeset_function)
-    |> assign_changeset(changeset_function, item, :resource_action, action.module.fields())
+    |> assign_changeset(changeset_function, item, action.module.fields(), :resource_action)
   end
 
   defp apply_item_actions(socket, action) when action in [:index, :resource_action] do
@@ -772,7 +772,7 @@ defmodule Backpex.LiveResource do
     |> apply_index_return_to()
   end
 
-  defp assign_changeset(socket, changeset_function, item, live_action, fields) do
+  defp assign_changeset(socket, changeset_function, item, fields, live_action) do
     metadata = Resource.build_changeset_metadata(socket.assigns)
     changeset = changeset_function.(item, default_attrs(live_action, fields, socket.assigns), metadata)
 

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -1173,17 +1173,17 @@ defmodule Backpex.LiveResource do
   end
 
   defp open_action_confirm_modal(socket, action, key) do
-    base_schema = action.module.base_schema(socket.assigns)
+    base_item = action.module.base_item(socket.assigns)
 
     changeset_function = &action.module.changeset/3
 
     metadata = Resource.build_changeset_metadata(socket.assigns)
 
-    changeset = changeset_function.(base_schema, %{}, metadata)
+    changeset = changeset_function.(base_item, %{}, metadata)
 
     socket =
       socket
-      |> assign(:item_action_base_schema, base_schema)
+      |> assign(:item_action_base_item, base_item)
       |> assign(:changeset_function, changeset_function)
       |> assign(:changeset, changeset)
       |> assign(:action_to_confirm, Map.put(action, :key, key))

--- a/lib/backpex/resource_action.ex
+++ b/lib/backpex/resource_action.ex
@@ -5,7 +5,7 @@ defmodule Backpex.ResourceAction do
   > #### `use Backpex.ResourceAction` {: .info}
   >
   > When you `use Backpex.ResourceAction`, the `Backpex.ResourceAction` module will set `@behavior Backpex.ResourceAction`.
-  > In addition it will implement the `Backpex.ResourceAction.init_change` function in order to generate a schemaless changeset by default.
+  > In addition it will implement the `c:base_item/1` function in order to generate a schemaless changeset by default.
   '''
 
   @doc """
@@ -25,12 +25,13 @@ defmodule Backpex.ResourceAction do
   @callback fields() :: list()
 
   @doc """
-  Initial change. The result will be passed to `c:changeset/3` in order to generate a changeset.
+  The base schema to use for the changeset. The result will be passed as the first parameter to `c:changeset/3` each time it is called.
 
-  This function is optional and can be used to use changesets with schemas in resource actions. If this function
-  is not provided a changeset will be generated automatically based on the provided types in `c:fields/0`.
+
+  This function is optional and can be used to use changesets with schemas in item actions. If this function is not provided,
+  a schemaless changeset will be created with the provided types from `c:fields/0`.
   """
-  @callback init_change(assigns :: map()) ::
+  @callback base_item(assigns :: map()) ::
               Ecto.Schema.t()
               | Ecto.Changeset.t()
               | {Ecto.Changeset.data(), Ecto.Changeset.types()}
@@ -69,7 +70,7 @@ defmodule Backpex.ResourceAction do
       @behaviour Backpex.ResourceAction
 
       @impl Backpex.ResourceAction
-      def init_change(_assigns) do
+      def base_item(_assigns) do
         types = Backpex.Field.changeset_types(fields())
 
         {%{}, types}

--- a/lib/backpex/resource_action.ex
+++ b/lib/backpex/resource_action.ex
@@ -5,7 +5,7 @@ defmodule Backpex.ResourceAction do
   > #### `use Backpex.ResourceAction` {: .info}
   >
   > When you `use Backpex.ResourceAction`, the `Backpex.ResourceAction` module will set `@behavior Backpex.ResourceAction`.
-  > In addition it will implement the `c:base_item/1` function in order to generate a schemaless changeset by default.
+  > In addition it will implement the `c:base_schema/1` function in order to generate a schemaless changeset by default.
   '''
 
   @doc """
@@ -30,7 +30,7 @@ defmodule Backpex.ResourceAction do
   This function is optional and can be used to use changesets with schemas in item actions. If this function is not provided,
   a schemaless changeset will be created with the provided types from `c:fields/0`.
   """
-  @callback base_item(assigns :: map()) ::
+  @callback base_schema(assigns :: map()) ::
               Ecto.Schema.t()
               | Ecto.Changeset.t()
               | {Ecto.Changeset.data(), Ecto.Changeset.types()}
@@ -69,7 +69,7 @@ defmodule Backpex.ResourceAction do
       @behaviour Backpex.ResourceAction
 
       @impl Backpex.ResourceAction
-      def base_item(_assigns) do
+      def base_schema(_assigns) do
         types = Backpex.Field.changeset_types(fields())
 
         {%{}, types}

--- a/lib/backpex/resource_action.ex
+++ b/lib/backpex/resource_action.ex
@@ -25,8 +25,7 @@ defmodule Backpex.ResourceAction do
   @callback fields() :: list()
 
   @doc """
-  The base schema to use for the changeset. The result will be passed as the first parameter to `c:changeset/3` each time it is called.
-
+  The base item / schema to use for the changeset. The result will be passed as the first parameter to `c:changeset/3` each time it is called.
 
   This function is optional and can be used to use changesets with schemas in item actions. If this function is not provided,
   a schemaless changeset will be created with the provided types from `c:fields/0`.


### PR DESCRIPTION
The term `init_change` is confusing because the result is used as the base schema / item for the changeset function.