### PR TITLE
Fix custom `handle_event` and `handle_info` couldn't be defined in Live Resource

### DIFF
--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -308,8 +308,8 @@ defmodule Backpex.LiveResource do
       import Backpex.HTML.Layout
       import Backpex.HTML.Resource
 
-      alias Backpex.Router
       alias Backpex.LiveResource
+      alias Backpex.Router
 
       @impl Phoenix.LiveView
       def handle_event(event, params, socket), do: LiveResource.handle_event(event, params, socket)

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -260,12 +260,6 @@ defmodule Backpex.LiveResource do
       def handle_params(params, url, socket), do: LiveResource.handle_params(params, url, socket)
 
       @impl Phoenix.LiveView
-      def handle_event(event, params, socket), do: LiveResource.handle_event(event, params, socket)
-
-      @impl Phoenix.LiveView
-      def handle_info(msg, socket), do: LiveResource.handle_info(msg, socket)
-
-      @impl Phoenix.LiveView
       def render(assigns), do: LiveResource.render(assigns)
 
       @impl Backpex.LiveResource
@@ -313,7 +307,15 @@ defmodule Backpex.LiveResource do
     quote do
       import Backpex.HTML.Layout
       import Backpex.HTML.Resource
+
       alias Backpex.Router
+      alias Backpex.LiveResource
+
+      @impl Phoenix.LiveView
+      def handle_event(event, params, socket), do: LiveResource.handle_event(event, params, socket)
+
+      @impl Phoenix.LiveView
+      def handle_info(msg, socket), do: LiveResource.handle_info(msg, socket)
 
       @impl Backpex.LiveResource
       def panels, do: []


### PR DESCRIPTION
Move `handle_event` and `handle_info` to `__before_compile__` block