### PR TITLE
Add new_item_builder option to Ecto Adapter

### DIFF
--- a/lib/backpex/adapters/ecto.ex
+++ b/lib/backpex/adapters/ecto.ex
@@ -44,7 +44,22 @@ defmodule Backpex.Adapters.Ecto do
       Otherwise you will likely get binding errors.
       """,
       type: {:fun, 3}
-    ]
+    ],
+    new_item_builder: [
+      doc: """
+      The function that creates new items. Usefull when you want to prefill form when crating new items. With this you can
+      implement "copy" action, create by template, etc.. You have access to socket.params and you can modify creation based
+      on it's values.
+
+      This function should accept the following parameters:
+
+      - `assigns` - `map()`
+
+      It should return an item with expected schema.
+      """,
+      type: {:fun, 1},
+      required: false
+    ],
   ]
 
   @moduledoc """

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -663,7 +663,10 @@ defmodule Backpex.LiveResource do
     if not live_resource.can?(socket.assigns, :new, nil), do: raise(Backpex.ForbiddenError)
 
     fields = live_resource.validated_fields() |> filtered_fields_by_action(socket.assigns, :new)
-    empty_item = schema.__struct__()
+
+    new_item = if (builder = live_resource.config(:adapter_config)[:new_item_builder]),
+      do: builder.(socket),
+      else: schema.__struct__()
 
     changeset_function = live_resource.config(:adapter_config)[:create_changeset]
 
@@ -671,8 +674,8 @@ defmodule Backpex.LiveResource do
     |> assign(:changeset_function, changeset_function)
     |> assign(:page_title, create_button_label)
     |> assign(:fields, fields)
-    |> assign(:item, empty_item)
-    |> assign_changeset(changeset_function, empty_item, fields, :new)
+    |> assign(:item, new_item)
+    |> assign_changeset(changeset_function, new_item, fields, :new)
   end
 
   defp apply_action(socket, :resource_action) do


### PR DESCRIPTION
This change allows you to change the default form prefill when creating a new entry. This is useful, for example, if we want to create an action to copy an item, or create an item based on a template - these cases are very common in administration.

Example of an action to create a copy of an item:

Add a copy action using item_action:

```elixir
defmodule MyAppWeb.Backpex.Actions.CopyPreparationCategory do
  use BackpexWeb, :item_action

  @impl Backpex.ItemAction
  def icon(assigns, _item) do
    ~H"""
    <Backpex.HTML.CoreComponents.icon name="hero-document-duplicate" class="h-5 w-5 cursor-pointer transition duration-75 hover:scale-110 hover:text-blue-600" />
    """
  end

  @impl Backpex.ItemAction
  def label(_assigns, _item), do: Backpex.translate("Copy")

  @impl Backpex.ItemAction
  def handle(socket, [item | _items], _data) do
    path =
      Router.get_path(socket, socket.assigns.live_resource, socket.assigns.params, :new, %{
        copy_from: item.id
      })

    {:ok, Phoenix.LiveView.push_patch(socket, to: path)}
  end
end
```
Add action to LiveResource:

```elixir
  @impl Backpex.LiveResource
  def item_actions(default_actions) do
    [
      {:copy, %{module: MyAppWeb.Backpex.Actions.CopyPreparationCategory, only: [:row]}}
      | default_actions
    ]
  end
```

![image](https://github.com/user-attachments/assets/2aa9c84e-2237-4b6b-9949-c0cd07c4c89d)


Up to now, everything can be done with standard Backpex tools. But we need to create an item with pre-filled values. This is not possible now, but modifying to multiple lines would allow such flexibility. 

I suggest to add new optional adapter option **new_item_builder** , its use would then look like this:

```elixir
use Backpex.LiveResource,
    adapter_config: [
      ...
      new_item_builder: &__MODULE__.builder/1 # new option
    ],
    ....

  def builder(socket) do
    # we have access to all parameters here
    source_id = socket.assigns.params["copy_from"]

    if source_id do
      source = Preparations.get_preparation_category!(source_id)
      %PreparationCategory{name: source.name, position: source.position}
    else
      %PreparationCategory{}
    end
  end
```

The implementation is very straightforward. Instead of the existing code for creating new items:
```elixir
# lib/backpex/live_resource.ex
    empty_item = schema.__struct__()
```
use this

```elixir
    new_item = if (builder = live_resource.config(:adapter_config)[:new_item_builder]),
      do: builder.(socket),
      else: schema.__struct__()
```

I think this small change would increase the possibilities that Backpex offers.
