### PR TITLE
Improve renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,17 +8,12 @@
     "github>pehbehbeh/renovate-config//workarounds/mixGitVersioning",
     "github>pehbehbeh/renovate-config//customManagers/hexEsbuild",
     "github>pehbehbeh/renovate-config//customManagers/hexTailwind",
-    ":reviewer(krns)"
+    ":reviewer(krns)",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "packageRules": [
     {
-      "matchManagers": [
-        "mix"
-      ],
-      "rangeStrategy": "update-lockfile"
-    },
-    {
-      "description": "Group updates to the Elixir base image",
+      "description": "Group dependency updates to the Elixir base image",
       "groupName": "Base Image",
       "matchDepNames": [
         "erlang",
@@ -28,7 +23,7 @@
       "pinDigests": false
     },
     {
-      "description": "Disable Ubuntu major updates",
+      "description": "Disable ubuntu major updates",
       "matchDepNames": [
         "ubuntu"
       ],
@@ -48,7 +43,24 @@
       "pinDigests": false
     },
     {
-      "description": "Label updates in demo directory",
+      "matchManagers": [
+        "mix"
+      ],
+      "rangeStrategy": "update-lockfile"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest"
+      ]
+    },
+    {
+      "description": "Label dependency updates in demo directory",
       "matchFileNames": [
         "demo/**"
       ],
@@ -59,7 +71,7 @@
       ]
     },
     {
-      "description": "Label updates in ci.yml",
+      "description": "Label dependency updates in ci.yml",
       "matchFileNames": [
         ".github/workflows/ci.yml"
       ],
@@ -68,12 +80,6 @@
         "dependencies",
         "{{categories}}"
       ]
-    },
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "automerge": true
     }
   ],
   "labels": [


### PR DESCRIPTION
- Add `pinGitHubActionDigestsToSemver` helper
- Limit github actions automerges to minor, patch, pin and pinDigest
- Update descriptions
- Reorder package rules