### PR TITLE
Fix params not passed to `get_path` in default `return_to` route

### DIFF
--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -338,7 +338,7 @@ defmodule Backpex.LiveResource do
 
       @impl Backpex.LiveResource
       def return_to(socket, assigns, _action, _item) do
-        Map.get(assigns, :return_to, Router.get_path(socket, assigns.live_resource, %{}, :index))
+        Map.get(assigns, :return_to, Router.get_path(socket, assigns.live_resource, assigns.params, :index))
       end
 
       @impl Backpex.LiveResource

--- a/lib/backpex/router.ex
+++ b/lib/backpex/router.ex
@@ -185,14 +185,30 @@ defmodule Backpex.Router do
       "/events"
       iex> Backpex.Router.put_route_params("/events", %{})
       "/events"
+      iex> put_route_params("/:id/users", %{})
+      ** (ArgumentError) Cannot build route '/:id/users' because required parameter 'id' is missing in the list of params.
   """
   def put_route_params(route, params) do
     route
     |> String.split("/")
     |> Enum.reduce("", fn
-      "", acc -> acc
-      ":" <> param, acc -> acc <> "/#{URI.encode_www_form(params[param])}"
-      path, acc -> acc <> "/#{path}"
+      "", acc ->
+        acc
+
+      ":" <> param, acc ->
+        case Map.fetch(params, param) do
+          {:ok, value} ->
+            acc <> "/#{URI.encode_www_form(value)}"
+
+          :error ->
+            raise ArgumentError,
+                  "Cannot build route '#{route}' because required parameter '#{param}' is missing in the list of params."
+        end
+
+        acc <> "/#{URI.encode_www_form(params[param])}"
+
+      path, acc ->
+        acc <> "/#{path}"
     end)
   end
 

--- a/lib/backpex/router.ex
+++ b/lib/backpex/router.ex
@@ -185,7 +185,7 @@ defmodule Backpex.Router do
       "/events"
       iex> Backpex.Router.put_route_params("/events", %{})
       "/events"
-      iex> put_route_params("/:id/users", %{})
+      iex> Backpex.Router.put_route_params("/:id/users", %{})
       ** (ArgumentError) Cannot build route '/:id/users' because required parameter 'id' is missing in the list of params.
   """
   def put_route_params(route, params) do


### PR DESCRIPTION
We did not pass the params to `get_path` in the default `return_to` implementation. This caused errors when nested routes were used (e.g., `/:id/users`). Besides passing the params, this PR also adds an understandable error message in case params are still missing to build route.