### PR TITLE
Add `index_editable` support for `Backpex.Fields.Boolean`

### DIFF
--- a/demo/lib/demo_web/live/post_live.ex
+++ b/demo/lib/demo_web/live/post_live.ex
@@ -117,7 +117,8 @@ defmodule DemoWeb.PostLive do
       published: %{
         module: Backpex.Fields.Boolean,
         label: "Published",
-        align: :center
+        align: :center,
+        index_editable: true
       },
       show_likes: %{
         module: Backpex.Fields.Boolean,

--- a/demo/lib/demo_web/live/user_live.ex
+++ b/demo/lib/demo_web/live/user_live.ex
@@ -143,8 +143,7 @@ defmodule DemoWeb.UserLive do
           },
           primary: %{
             module: Backpex.Fields.Boolean,
-            label: "Primary",
-            index_editable: true
+            label: "Primary"
           }
         ],
         options_query: fn query, _assigns ->

--- a/demo/lib/demo_web/live/user_live.ex
+++ b/demo/lib/demo_web/live/user_live.ex
@@ -143,7 +143,8 @@ defmodule DemoWeb.UserLive do
           },
           primary: %{
             module: Backpex.Fields.Boolean,
-            label: "Primary"
+            label: "Primary",
+            index_editable: true
           }
         ],
         options_query: fn query, _assigns ->

--- a/lib/backpex/fields/boolean.ex
+++ b/lib/backpex/fields/boolean.ex
@@ -54,7 +54,7 @@ defmodule Backpex.Fields.Boolean do
         <BackpexForm.input
           type="toggle"
           field={@form[:value]}
-          input_class={["toggle toggle-sm  toggle-success", "hover:input-bordered"]}
+          input_class={["toggle toggle-sm toggle-success", "hover:input-bordered"]}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
           readonly={@readonly}

--- a/lib/backpex/fields/boolean.ex
+++ b/lib/backpex/fields/boolean.ex
@@ -38,4 +38,35 @@ defmodule Backpex.Fields.Boolean do
     </div>
     """
   end
+  @impl Backpex.Field
+  def render_index_form(assigns) do
+    form = to_form(%{"value" => assigns.value}, as: :index_form)
+
+    assigns =
+      assigns
+      |> assign_new(:form, fn -> form end)
+      |> assign_new(:valid, fn -> true end)
+
+    ~H"""
+    <div>
+      <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
+
+      <BackpexForm.input
+          type="toggle"
+          field={@form[:value]}
+          input_class={["toggle toggle-sm  toggle-success", "hover:input-bordered"]}
+          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+          readonly={@readonly}
+          hide_errors
+        />
+      </.form>
+    </div>
+    """
+  end
+
+  @impl Phoenix.LiveComponent
+  def handle_event("update-field", %{"index_form" => %{"value" => value}}, socket) do
+    Backpex.Field.handle_index_editable(socket, value, Map.put(%{}, socket.assigns.name, value))
+  end
 end

--- a/lib/backpex/fields/boolean.ex
+++ b/lib/backpex/fields/boolean.ex
@@ -38,6 +38,7 @@ defmodule Backpex.Fields.Boolean do
     </div>
     """
   end
+
   @impl Backpex.Field
   def render_index_form(assigns) do
     form = to_form(%{"value" => assigns.value}, as: :index_form)
@@ -50,8 +51,7 @@ defmodule Backpex.Fields.Boolean do
     ~H"""
     <div>
       <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
-
-      <BackpexForm.input
+        <BackpexForm.input
           type="toggle"
           field={@form[:value]}
           input_class={["toggle toggle-sm  toggle-success", "hover:input-bordered"]}


### PR DESCRIPTION
Okay, another simple change. I kind of find it's convenient to edit boolean fields  in the index(list) view. 
So I've added the 
```elixir
render_index_form(assigns)
```
and 
```elixir
handle_event("update-field", %{"index_form" => %{"value" => value}}, socket)
```
callbacks.

I've used a slightly smaller size toggle that you use in the `render_form` callback.

many thanks as usual for the great work.