### PR TITLE
Fix MultiSelect crash when returning non strings as options

### DIFF
--- a/lib/backpex/fields/multi_select.ex
+++ b/lib/backpex/fields/multi_select.ex
@@ -61,7 +61,12 @@ defmodule Backpex.Fields.MultiSelect do
   defp assign_options(socket) do
     %{assigns: %{field_options: field_options} = assigns} = socket
 
-    options = assigns |> field_options.options.() |> Enum.map(fn {label, value} -> {to_string(label), to_string(value)} end)
+    options =
+      assigns
+      |> field_options.options.()
+      |> Enum.map(fn {label, value} ->
+        {to_string(label), to_string(value)}
+      end)
 
     assign(socket, :options, options)
   end

--- a/lib/backpex/fields/multi_select.ex
+++ b/lib/backpex/fields/multi_select.ex
@@ -61,7 +61,7 @@ defmodule Backpex.Fields.MultiSelect do
   defp assign_options(socket) do
     %{assigns: %{field_options: field_options} = assigns} = socket
 
-    options = field_options.options.(assigns)
+    options = assigns |> field_options.options.() |> Enum.map(fn {label, value} -> {to_string(label), to_string(value)} end)
 
     assign(socket, :options, options)
   end


### PR DESCRIPTION
When returning non-string options, as shown in the example below:

```elixir
medical_specialties_input: %{
  module: Backpex.Fields.MultiSelect,
  label: gettext("Especialidades"),
  options: fn _assigns ->
    Accounts.list_medical_specialties()
    |> Enum.map(&{&1.title, &1.id})
  end
}
```

and error occurs:

** (FunctionClauseError) no function clause matching in anonymous fn/1 in Backpex.HTML.Form.selected?/2

To make Backpex more robust, it’s essential to ensure that the returned options are converted to strings instead of raising this cryptic error.