### PR TITLE
Allow `select_merge` in `item_query` (index)

### DIFF
--- a/lib/backpex/adapters/ecto.ex
+++ b/lib/backpex/adapters/ecto.ex
@@ -95,6 +95,7 @@ defmodule Backpex.Adapters.Ecto do
 
     list_query(criteria, assigns, live_resource)
     |> exclude(:preload)
+    |> exclude(:select)
     |> subquery()
     |> config[:repo].aggregate(:count)
     |> then(fn count -> {:ok, count} end)


### PR DESCRIPTION
Allow `select_merge` in `item_query` when `live_action` is `:index`. 

Before this change you cannot use `select_merge` on index because it collides with the count query for the pagination and results in the following error:

```
the following exception happened when compiling a subquery.

    ** (Ecto.QueryError) atoms, structs, maps, lists, tuples and sources are not allowed as map values in subquery, got: `%{child_count: {:subquery, 0}}` in query:
    
    from v0 in MyApp.Parent,
      as: :parent,
      select: merge(v0, %{
      child_count:
        subquery(
          #Ecto.Query<from a0 in MyApp.Child, where: a0.parent_id == parent_as(:parent).id, select: %{result: count()}>
        )
    })
    

The subquery originated from the following query:

from v0 in subquery(from v0 in MyApp.Parent,
  as: :parent,
  select: merge(v0, %{
  child_count:
    subquery(
      #Ecto.Query<from a0 in MyApp.Child, where: a0.parent_id == parent_as(:parent).id, select: count()>
    )
})),
  select: count()
```