### PR TITLE
Add form action to `return_to`

### DIFF
--- a/demo/lib/demo_web/live/short_link_live.ex
+++ b/demo/lib/demo_web/live/short_link_live.ex
@@ -22,7 +22,7 @@ defmodule DemoWeb.ShortLinkLive do
   def can?(_assigns, :delete, _item), do: false
   def can?(_assigns, _action, _item), do: true
 
-  def return_to(_socket, _assigns, :edit, _item) do
+  def return_to(_socket, _assigns, :edit, _form_action, _item) do
     # since the primary key might be updated, we go to the index page
     ~p"/admin/short-links"
   end

--- a/guides/live_resource/navigation.md
+++ b/guides/live_resource/navigation.md
@@ -1,19 +1,37 @@
 # Navigation
 
-
-By default Backpex redirects to the index page after creating or updating an item. You can customize this behavior.
+By default, Backpex redirects to the previous resource path (index or show view) after creating or updating an item, 
+but you can customize this behavior.
 
 ## Configuration
 
-To define a custom navigation path, you need to implement the [return_to/4](Backpex.LiveResource.html#c:return_to/4) callback in your resource configuration file:
+To define a custom navigation path, you need to implement the [return_to/5](Backpex.LiveResource.html#c:return_to/5) callback in your resource configuration file:
 
 ```elixir
 # in your resource configuration file
-
 @impl Backpex.LiveResource
-def return_to(socket, assigns, live_action, item) do
+def return_to(socket, assigns, live_action, _form_action, item) do
     ~p"/home"
 end
 ```
 
-The example above will redirect to the `/home` path after saving an item.
+The example above will always redirect to the `/home` path after editing an item.
+
+## Available Live Actions
+
+Backpex supports the following live actions:
+
+- `:index` - The list view of your resource
+- `:new` - The form for creating a new resource
+- `:edit` - The form for editing an existing resource
+- `:show` - The detailed view of a single resource
+- `:resource_action` - An open resource action on the list view
+
+## Form Actions
+
+When working with forms (in `:new` or  `:edit` live actions), the following form actions are available:
+
+- `:save` - When a form is successfully submitted aka the "Save" button was clicked
+- `:cancel` - When a form submission is canceled aka the "Cancel" button was clicked
+
+For all other live actions, the form_action will be `nil`.

--- a/guides/upgrading/v0.12.md
+++ b/guides/upgrading/v0.12.md
@@ -35,3 +35,28 @@ In case you still want to overwrite the settings, the `name` option is now calle
 The option for `event_prefix` was removed. Broadcasted events are just called `created`, `updated` and `deleted` now.
 
 See [Listen to PubSub Events](live_resource/listen-to-pubsub-events.md) for more info.
+
+## `return_to/4` becomes `return_to/5`
+
+We have added a `form_action` parameter to the `return_to` function.
+This allows you to customize the URL based on whether the user cancels or saves an item.
+
+If you previously had something like this in your LiveResource:
+
+```elixir
+@impl Backpex.LiveResource
+def return_to(socket, assigns, _live_action, _item) do
+  ~p"/admin/posts"
+end
+```
+
+change it to:
+
+```elixir
+@impl Backpex.LiveResource
+def return_to(socket, assigns, _live_action, _form_action, _item) do
+  ~p"/admin/posts"
+end
+```
+
+For more information on the new parameter and available options see the [Navigation Guide](/guides/live_resource/navigation.md)

--- a/lib/backpex/html/resource/form_component.html.heex
+++ b/lib/backpex/html/resource/form_component.html.heex
@@ -60,7 +60,7 @@
             {@action_to_confirm.module.confirm_label(assigns)}
           </button>
         <% else %>
-          <.link navigate={@live_resource.return_to(@socket, assigns, @live_action, @item)}>
+          <.link navigate={@live_resource.return_to(@socket, assigns, @live_action, :cancel, @item)}>
             <button type="button" class="btn btn-ghost">
               {Backpex.translate("Cancel")}
             </button>

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -198,7 +198,7 @@ defmodule Backpex.FormComponent do
   defp handle_save(socket, key, params, save_type \\ "save")
 
   defp handle_save(socket, :new, params, save_type) do
-    %{assigns: %{live_resource: live_resource, item: item} = assigns} = socket
+    %{assigns: %{live_resource: live_resource, item: item, live_action: live_action} = assigns} = socket
 
     opts = [
       assocs: Map.get(assigns, :assocs, []),
@@ -212,7 +212,7 @@ defmodule Backpex.FormComponent do
 
     case Resource.insert(item, params, socket.assigns, live_resource, opts) do
       {:ok, item} ->
-        return_to = return_to_path(save_type, live_resource, socket, socket.assigns, item, :new)
+        return_to = return_to_path(save_type, live_resource, socket, socket.assigns, item, live_action)
 
         socket
         |> assign(:show_form_errors, false)
@@ -234,7 +234,8 @@ defmodule Backpex.FormComponent do
   end
 
   defp handle_save(socket, :edit, params, save_type) do
-    %{live_resource: live_resource, singular_name: singular_name, item: item, fields: fields} = socket.assigns
+    %{live_resource: live_resource, singular_name: singular_name, item: item, fields: fields, live_action: live_action} =
+      socket.assigns
 
     opts = [
       assocs: Map.get(socket.assigns, :assocs, []),
@@ -248,7 +249,7 @@ defmodule Backpex.FormComponent do
 
     case Resource.update(item, params, fields, socket.assigns, live_resource, opts) do
       {:ok, item} ->
-        return_to = return_to_path(save_type, live_resource, socket, socket.assigns, item, :edit)
+        return_to = return_to_path(save_type, live_resource, socket, socket.assigns, live_action, item)
         info_msg = Backpex.translate({"%{resource} has been edited successfully.", %{resource: singular_name}})
 
         socket
@@ -395,7 +396,7 @@ defmodule Backpex.FormComponent do
     end)
   end
 
-  defp return_to_path("continue", _live_resource, _socket, %{current_url: url}, item, :new) do
+  defp return_to_path("continue", _live_resource, _socket, %{current_url: url}, :new, item) do
     url
     |> URI.parse()
     |> Map.get(:path)
@@ -403,12 +404,16 @@ defmodule Backpex.FormComponent do
     |> Kernel.<>("/#{item.id}/edit")
   end
 
-  defp return_to_path("continue", _live_resource, _socket, %{current_url: url}, _item, :edit) do
+  defp return_to_path("continue", _live_resource, _socket, %{current_url: url}, :edit, _item) do
     URI.parse(url).path
   end
 
-  defp return_to_path(_save_type, live_resource, socket, assigns, item, type) do
-    live_resource.return_to(socket, assigns, type, item)
+  defp return_to_path("save", live_resource, socket, assigns, live_action, item) do
+    live_resource.return_to(socket, assigns, live_action, :save, item)
+  end
+
+  defp return_to_path(_save_type, live_resource, socket, assigns, live_action, item) do
+    live_resource.return_to(socket, assigns, live_action, nil, item)
   end
 
   defp put_upload_change(change, socket, action) do

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -199,9 +199,15 @@ defmodule Backpex.LiveResource do
               Phoenix.LiveView.Socket.t()
 
   @doc """
-  This function navigates to the specified path when an item has been created or updated. Defaults to the previous resource path (index or edit).
+  This function navigates to the specified path when an item has been created or updated. Defaults to the previous resource path (index or show).
   """
-  @callback return_to(socket :: Phoenix.LiveView.Socket.t(), assigns :: map(), action :: atom(), item :: map()) ::
+  @callback return_to(
+              socket :: Phoenix.LiveView.Socket.t(),
+              assigns :: map(),
+              live_action :: atom(),
+              form_action :: atom(),
+              item :: map()
+            ) ::
               binary()
 
   @doc """
@@ -337,7 +343,7 @@ defmodule Backpex.LiveResource do
       def on_item_deleted(socket, _item), do: socket
 
       @impl Backpex.LiveResource
-      def return_to(socket, assigns, _action, _item) do
+      def return_to(socket, assigns, _live_action, _form_action, _item) do
         Map.get(assigns, :return_to, Router.get_path(socket, assigns.live_resource, assigns.params, :index))
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -179,6 +179,7 @@ defmodule Backpex.MixProject do
       "guides/custom_labels_and_translations/custom-labels-and-translations.md",
 
       # Upgrade Guides
+      "guides/upgrading/v0.12.md",
       "guides/upgrading/v0.11.md",
       "guides/upgrading/v0.10.md",
       "guides/upgrading/v0.9.md",


### PR DESCRIPTION
Adds `form_action` parameter to `return_to` function to distinguish between save and cancel action.