### PR TITLE
Add error handling for missing routes in Router functions

### DIFF
--- a/lib/backpex/router.ex
+++ b/lib/backpex/router.ex
@@ -172,9 +172,10 @@ defmodule Backpex.Router do
         path
 
       nil ->
-        raise ArgumentError,
-              "Could not find route for #{inspect(module)} with action #{inspect(action)}. " <>
-                "Make sure you have defined the route in your router."
+        raise ArgumentError, """
+        Could not find route for #{inspect(module)} with action #{inspect(action)}.
+        Make sure you have defined the route in your router.
+        """
     end
   end
 
@@ -234,10 +235,11 @@ defmodule Backpex.Router do
         path
 
       nil ->
-        raise ArgumentError,
-              "Could not find backpex_cookies route. " <>
-                "Make sure you have added backpex_routes to your router. " <>
-                "See: https://hexdocs.pm/backpex/0.11.0/installation.html#add-backpex-routes"
+        raise ArgumentError, """
+        Could not find backpex_cookies route. Make sure you have added backpex_routes to your router.
+
+        See: https://hexdocs.pm/backpex/installation.html#add-backpex-routes
+        """
     end
   end
 

--- a/lib/backpex/router.ex
+++ b/lib/backpex/router.ex
@@ -162,12 +162,20 @@ defmodule Backpex.Router do
   defp maybe_put_query_params(path, encoded_query_params), do: path <> "?" <> encoded_query_params
 
   defp get_route_path(socket, module, action) do
-    %{path: path} =
+    route =
       Enum.find(Map.get(socket, :router).__routes__(), fn element ->
         element[:metadata][:log_module] == module and element[:plug_opts] == action
       end)
 
-    path
+    case route do
+      %{path: path} ->
+        path
+
+      nil ->
+        raise ArgumentError,
+              "Could not find route for #{inspect(module)} with action #{inspect(action)}. " <>
+                "Make sure you have defined the route in your router."
+    end
   end
 
   @doc """
@@ -216,12 +224,21 @@ defmodule Backpex.Router do
   Finds the cookie path by the given socket.
   """
   def cookie_path(socket) do
-    %{path: path} =
+    route =
       Enum.find(Map.get(socket, :router).__routes__(), fn element ->
         element[:plug] == Backpex.CookieController and element[:plug_opts] == :update
       end)
 
-    path
+    case route do
+      %{path: path} ->
+        path
+
+      nil ->
+        raise ArgumentError,
+              "Could not find backpex_cookies route. " <>
+                "Make sure you have added backpex_routes to your router. " <>
+                "See: https://hexdocs.pm/backpex/0.11.0/installation.html#add-backpex-routes"
+    end
   end
 
   defp maybe_to_string(value) when is_atom(value), do: Atom.to_string(value)


### PR DESCRIPTION
closes #986 

This pull request includes changes to improve error handling in the `Backpex.Router` module by adding checks for missing routes and raising appropriate errors when routes are not found.

Improvements to error handling:

* [`lib/backpex/router.ex`](diffhunk://#diff-c6c09bf8961252686399d6a39c845d6e0b4c1655cae27cf0be52e2e44d260bc6L165-R178): Modified the `get_route_path` function to handle cases where a route is not found, raising an `ArgumentError` with a descriptive message.
* [`lib/backpex/router.ex`](diffhunk://#diff-c6c09bf8961252686399d6a39c845d6e0b4c1655cae27cf0be52e2e44d260bc6L219-R241): Updated the `cookie_path` function to raise an `ArgumentError` when the `backpex_cookies` route is missing, including instructions on how to add the route.