### PR TITLE
fix and improve flash message styles and add alert component

### DIFF
--- a/demo/lib/demo_web/live/film_review_live.ex
+++ b/demo/lib/demo_web/live/film_review_live.ex
@@ -18,12 +18,10 @@ defmodule DemoWeb.FilmReviewLive do
   @impl Backpex.LiveResource
   def render_resource_slot(assigns, :index, :before_page_title) do
     ~H"""
-    <div role="alert" class="alert alert-info my-4 text-sm">
-      <Backpex.HTML.CoreComponents.icon name="hero-information-circle" class="h-5 w-5" />
-      <span>
-        This resource uses the full-text search functionality. The search accepts web search query operators. For example, a dash (-) excludes words.
-      </span>
-    </div>
+    <Backpex.HTML.Layout.alert kind={:info} closable={false}>
+      This resource uses the full-text search functionality. The search accepts web search query operators. For example,
+      a dash (-) excludes words.
+    </Backpex.HTML.Layout.alert>
     """
   end
 

--- a/demo/lib/demo_web/live/ticket_live.ex
+++ b/demo/lib/demo_web/live/ticket_live.ex
@@ -15,14 +15,11 @@ defmodule DemoWeb.TicketLive do
   @impl Backpex.LiveResource
   def render_resource_slot(assigns, :index, :before_page_title) do
     ~H"""
-    <div role="alert" class="alert alert-info my-4 text-sm">
-      <Backpex.HTML.CoreComponents.icon name="hero-information-circle" class="h-5 w-5" />
-      <p>
-        This resource uses the <strong>Ash adapter</strong>, which is currently in a very early alpha stage.
-        Currently, only <strong>index</strong>, <strong>show</strong> and <strong>delete</strong> are functional in a
-        very basic form. We are working on supporting more Backpex features in the future.
-      </p>
-    </div>
+    <Backpex.HTML.Layout.alert kind={:info} closable={false}>
+      This resource uses the <strong>Ash adapter</strong>, which is currently in a very early alpha stage.
+      Currently, only <strong>index</strong>, <strong>show</strong> and <strong>delete</strong> are functional in a
+      very basic form. We are working on supporting more Backpex features in the future.
+    </Backpex.HTML.Layout.alert>
     """
   end
 


### PR DESCRIPTION
- add flexible `alert/1` component with styles for `info`, `success`, `warning` and `error`
- fix styles (background + button hover) on error alerts (see below)

### before

default:

![Bildschirmfoto 2025-04-03 um 14 06 23](https://github.com/user-attachments/assets/914a9dd4-0243-40d8-821b-50e060a09566)

button hover:

![Bildschirmfoto 2025-04-03 um 14 06 31](https://github.com/user-attachments/assets/a0d9a1f1-7551-4082-9654-3c562a28e7db)

### after

default:

![Bildschirmfoto 2025-04-03 um 14 47 46](https://github.com/user-attachments/assets/6fd0f293-09cb-48fc-bb4a-b3ddb9ee4114)

button hover:

![Bildschirmfoto 2025-04-03 um 14 47 27](https://github.com/user-attachments/assets/c4573dc8-060e-4bbe-8e47-f6f720e40897)


