### PR TITLE
Fix `HasMany` shows error if input was not used yet

### DIFF
--- a/lib/backpex/fields/has_many.ex
+++ b/lib/backpex/fields/has_many.ex
@@ -206,7 +206,7 @@ defmodule Backpex.Fields.HasMany do
                 </span>
               </label>
 
-              <input type="hidden" id={"has-many-#{@name}-hidden-input"} name={"#{@form[@name].name}[]"} value="" />
+              <input class="hidden" id={"has-many-#{@name}-hidden-input"} name={"#{@form[@name].name}[]"} value="" />
 
               <input
                 :for={value <- @selected_ids}


### PR DESCRIPTION
If there are no options for the `HasMany`, errors are displayed immediately after any form input is used.

I guess, the reason is that no checkboxes are rendered in this case expect from the hidden input.

Hiding the hidden input with CSS and removing `type="hidden"` resolves the issue.

https://github.com/user-attachments/assets/f2115de1-244e-42de-82ee-48a914e3f990

