### PR TITLE
Add `allowed_schemes` option to `Backpex.Fields.URL`

### DIFF
--- a/lib/backpex/fields/url.ex
+++ b/lib/backpex/fields/url.ex
@@ -70,7 +70,7 @@ defmodule Backpex.Fields.URL do
   defp valid_url?(value, field_options) when is_binary(value) do
     case URI.new(value) do
       {:ok, %URI{scheme: scheme}} ->
-        is_nil(scheme) or scheme in field_options.allowed_schemes
+        is_nil(scheme) or String.downcase(scheme) in field_options.allowed_schemes
 
       {:error, _part} ->
         false


### PR DESCRIPTION
Using a URL with an unsupported schema in a `Backpex.Fields.URL` field results in a runtime error:

> unsupported scheme given to <.link>. In case you want to link to an
unknown or unsafe scheme, such as javascript, use a tuple: {:javascript, rest}

This MR introduces a new `allowed_schemes` option for `Backpex.Fields.URL`. This ensures that values are validated properly and gives developers more flexibility over inserted URLs. For example, you may prefer not to link to unsafe HTTP links.