### PR TITLE
Remove `render_form_readonly` callback from fields

### DIFF
--- a/guides/fields/readonly.md
+++ b/guides/fields/readonly.md
@@ -1,14 +1,14 @@
 # Readonly
 
-Fields can be configured to be readonly. In edit view, these fields are rendered with the additional HTML attributes `readonly` and `disabled`, ensuring that the user cannot interact with the field or change its value.
+Fields can be configured to be readonly. In edit view, these fields are rendered with the additional HTML attributes `readonly` and `disabled`, ensuring that users cannot interact with the field or change its value.
 
-In index view, if readonly and index editable is set to `true`, forms will be rendered with the `readonly` HTML attribute.
+In index view, if readonly and index editable are both set to true, forms will be rendered with the `readonly` HTML attribute.
 
 ## Supported fields
 
-On index view, read-only is supported for all fields with the index editable option (see [Index Edit](index-edit.md)).
+On index view, readonly is supported for all fields with the index editable option (see [Index Edit](index-edit.md)).
 
-On edit view, read-only is supported for:
+On edit view, readonly is supported for:
 - `Backpex.Fields.Date`
 - `Backpex.Fields.DateTime`
 - `Backpex.Fields.Number`
@@ -17,19 +17,19 @@ On edit view, read-only is supported for:
 
 ## Configuration
 
-To enable read-only for a field, you need to set the `readonly` option to `true` in the field configuration. This key must contain either a boolean value or a function that returns a boolean value.
+To enable readonly for a field, you need to set the `readonly` option to true in the field configuration. This key must contain either a boolean value or a function that returns a boolean value.
 
 ```elixir
 # in your resource configuration file
 def fields do
 [
-    rating: %{
-        module: Backpex.Fields.Text,
-        label: "Rating",
-        readonly: fn assigns ->
-            assigns.current_user.role in [:employee]
-        end
-    }
+  rating: %{
+    module: Backpex.Fields.Text,
+    label: "Rating",
+    readonly: fn assigns ->
+        assigns.current_user.role in [:employee]
+    end
+  }
 ]
 end
 ```
@@ -38,41 +38,54 @@ end
 # in your resource configuration file
 def fields do
 [
-    rating: %{
-        module: Backpex.Fields.Text,
-        label: "Rating",
-        readonly: true
-    }
+  rating: %{
+    module: Backpex.Fields.Text,
+    label: "Rating",
+    readonly: true
+  }
 ]
 end
 ```
 
 ## Readonly for custom fields
 
-You can also add readonly functionality to a custom field. To do this, you need to define a [`render_form_readonly/1`](Backpex.Field.html#c:render_form_readonly/1) function. This function must return markup to be used when readonly is enabled.
+You can also add readonly functionality to a custom field. To do this, you need to handle the readonly state in the `c:Backpex.Field.render_form/1` function of your custom field. You can access the readonly value from the assigns, which will be `true` or `false`.
 
 ```elixir
 @impl Backpex.Field
-def render_form_readonly(assigns) do
+def render_form(assigns) do
 ~H"""
 <div>
-    <Layout.field_container>
-        <:label>
-            <Layout.input_label text={@field[:label]} />
-        </:label>
-        <BackpexForm.input
-        type="text"
-        field={@form[@name]}
-        translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
-        phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
-        phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
-        readonly
-        disabled
-        />
-    </Layout.field_container>
+  <Layout.field_container>
+    <:label>
+        <Layout.input_label text={@field[:label]} />
+    </:label>
+    <BackpexForm.input
+      type="text"
+      field={@form[@name]}
+      translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
+      phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
+      phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
+      readonly={@readonly}
+      disabled={@readonly}
+    />
+  </Layout.field_container>
 </div>
 """
 end
 ```
 
-When defining a custom field with index editable support, you need to handle the readonly state in the index editable markup. There is a `readonly` value in the assigns, which will be `true` or `false`.
+If your readonly logic is more complex, you can also use a dedicated function that returns the markup for the readonly state.
+
+```elixir
+@impl Backpex.Field
+def render_form(%{readonly: true} = assigns) do
+# Return readonly markup
+end
+
+def render_form(%{readonly: false} = assigns) do
+# Return editable markup
+end
+```
+
+When defining a custom field with index editable support, you need to handle the readonly state in `c:Backpex.Field.render_index_form/1`. There is also a readonly value in the assigns, which will be `true` or `false`.

--- a/guides/upgrading/v0.14.md
+++ b/guides/upgrading/v0.14.md
@@ -81,3 +81,22 @@ def changeset(change, attrs, _metadata) do
   |> Ecto.Changeset.validate_required([:field1])
 end
 ```
+
+## `render_form_readonly/1` callback has been removed
+
+We removed the `render_form_readonly/1` callback from fields. Instead, `readonly` must be handled directly in the `c:Backpex.Field.render_form/1` callback.
+
+Make sure to update your custom fields accordingly. The `readonly` value will be available in the assigns, which will be `true` or `false`.
+
+```elixir
+@impl Backpex.Field
+def render_form(%{readonly: true} = assigns) do
+# render readonly field
+end
+
+def render_form(%{readonly: false} = assigns) do
+# render editable field
+end
+```
+
+See the [Readonly guide](readonly.md) for more details.

--- a/guides/upgrading/v0.14.md
+++ b/guides/upgrading/v0.14.md
@@ -91,11 +91,11 @@ Make sure to update your custom fields accordingly. The `readonly` value will be
 ```elixir
 @impl Backpex.Field
 def render_form(%{readonly: true} = assigns) do
-# render readonly field
+# Render readonly field
 end
 
 def render_form(%{readonly: false} = assigns) do
-# render editable field
+# Render editable field
 end
 ```
 

--- a/lib/backpex/field.ex
+++ b/lib/backpex/field.ex
@@ -259,11 +259,8 @@ defmodule Backpex.Field do
       def render(%{type: :index} = assigns) do
         if Backpex.Field.index_editable_enabled?(assigns.field_options, assigns) do
           case Map.get(assigns.field_options, :render_index_form) do
-            nil ->
-              apply(__MODULE__, :render_index_form, [assigns])
-
-            func ->
-              func.(assigns)
+            fun when is_function(fun, 1) -> fun.(assigns)
+            nil -> apply(__MODULE__, :render_index_form, [assigns])
           end
         else
           Map.get(assigns.field_options, :render, &render_value/1).(assigns)

--- a/lib/backpex/field.ex
+++ b/lib/backpex/field.ex
@@ -150,11 +150,6 @@ defmodule Backpex.Field do
   @callback render_index_form(assigns :: map()) :: %Phoenix.LiveView.Rendered{}
 
   @doc """
-  Used to render the readonly version of the field.
-  """
-  @callback render_form_readonly(assigns :: map()) :: %Phoenix.LiveView.Rendered{}
-
-  @doc """
   The field to be displayed on index views. In most cases this is the name / key configured in the corresponding field definition.
   In fields with associations this value often differs from the name / key. The function will receive the field definition.
   """
@@ -211,7 +206,7 @@ defmodule Backpex.Field do
             ) ::
               Ecto.Query.dynamic_expr()
 
-  @optional_callbacks render_form_readonly: 1, render_index_form: 1
+  @optional_callbacks render_index_form: 1
 
   @doc """
   Returns the default config schema.
@@ -277,16 +272,9 @@ defmodule Backpex.Field do
 
       @impl Phoenix.LiveComponent
       def render(%{type: :form} = assigns) do
-        if Backpex.Field.readonly?(assigns.field_options, assigns) do
-          case Map.get(assigns.field_options, :render_form_readonly) do
-            nil ->
-              apply(__MODULE__, :render_form_readonly, [assigns])
-
-            func ->
-              func.(assigns)
-          end
-        else
-          Map.get(assigns.field_options, :render_form, &render_form/1).(assigns)
+        case Map.get(assigns.field_options, :render_form) do
+          fun when is_function(fun, 1) -> fun.(assigns)
+          nil -> apply(__MODULE__, :render_form, [assigns])
         end
       end
 

--- a/lib/backpex/fields/date.ex
+++ b/lib/backpex/fields/date.ex
@@ -112,28 +112,8 @@ defmodule Backpex.Fields.Date do
           help_text={Backpex.Field.help_text(@field_options, assigns)}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
-        />
-      </Layout.field_container>
-    </div>
-    """
-  end
-
-  @impl Backpex.Field
-  def render_form_readonly(assigns) do
-    ~H"""
-    <div>
-      <Layout.field_container>
-        <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
-          <Layout.input_label text={@field_options[:label]} />
-        </:label>
-        <BackpexForm.input
-          type="date"
-          field={@form[@name]}
-          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
-          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
-          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
-          readonly
-          disabled
+          readonly={@readonly}
+          disabled={@readonly}
         />
       </Layout.field_container>
     </div>

--- a/lib/backpex/fields/date_time.ex
+++ b/lib/backpex/fields/date_time.ex
@@ -112,28 +112,8 @@ defmodule Backpex.Fields.DateTime do
           help_text={Backpex.Field.help_text(@field_options, assigns)}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
-        />
-      </Layout.field_container>
-    </div>
-    """
-  end
-
-  @impl Backpex.Field
-  def render_form_readonly(assigns) do
-    ~H"""
-    <div>
-      <Layout.field_container>
-        <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
-          <Layout.input_label text={@field_options[:label]} />
-        </:label>
-        <BackpexForm.input
-          type="datetime-local"
-          field={@form[@name]}
-          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
-          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
-          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
-          readonly
-          disabled
+          readonly={@readonly}
+          disabled={@readonly}
         />
       </Layout.field_container>
     </div>

--- a/lib/backpex/fields/number.ex
+++ b/lib/backpex/fields/number.ex
@@ -54,30 +54,8 @@ defmodule Backpex.Fields.Number do
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
-        />
-      </Layout.field_container>
-    </div>
-    """
-  end
-
-  @impl Backpex.Field
-  def render_form_readonly(assigns) do
-    ~H"""
-    <div>
-      <Layout.field_container>
-        <:label align={Backpex.Field.align_label(@field_options, assigns)}>
-          <Layout.input_label text={@field_options[:label]} />
-        </:label>
-        <BackpexForm.input
-          type="text"
-          field={@form[@name]}
-          placeholder={@field_options[:placeholder]}
-          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
-          help_text={Backpex.Field.help_text(@field_options, assigns)}
-          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
-          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
-          readonly
-          disabled
+          readonly={@readonly}
+          disabled={@readonly}
         />
       </Layout.field_container>
     </div>

--- a/lib/backpex/fields/number.ex
+++ b/lib/backpex/fields/number.ex
@@ -48,7 +48,7 @@ defmodule Backpex.Fields.Number do
           <Layout.input_label text={@field_options[:label]} />
         </:label>
         <BackpexForm.input
-          type="text"
+          type="number"
           field={@form[@name]}
           placeholder={@field_options[:placeholder]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
@@ -76,7 +76,7 @@ defmodule Backpex.Fields.Number do
       <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
         <BackpexForm.input
           id={"index-form-input-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
-          type="text"
+          type="number"
           field={@form[:value]}
           placeholder={@field_options[:placeholder]}
           input_class={["input input-sm", @valid && "not-hover:input-ghost", !@valid && "input-error bg-error/10"]}

--- a/lib/backpex/fields/text.ex
+++ b/lib/backpex/fields/text.ex
@@ -54,29 +54,8 @@ defmodule Backpex.Fields.Text do
           help_text={Backpex.Field.help_text(@field_options, assigns)}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
-        />
-      </Layout.field_container>
-    </div>
-    """
-  end
-
-  @impl Backpex.Field
-  def render_form_readonly(assigns) do
-    ~H"""
-    <div>
-      <Layout.field_container>
-        <:label align={Backpex.Field.align_label(@field_options, assigns, :center)}>
-          <Layout.input_label text={@field_options[:label]} />
-        </:label>
-        <BackpexForm.input
-          type="text"
-          field={@form[@name]}
-          placeholder={@field_options[:placeholder]}
-          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
-          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
-          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
-          readonly
-          disabled
+          readonly={@readonly}
+          disabled={@readonly}
         />
       </Layout.field_container>
     </div>

--- a/lib/backpex/fields/textarea.ex
+++ b/lib/backpex/fields/textarea.ex
@@ -64,30 +64,8 @@ defmodule Backpex.Fields.Textarea do
           help_text={Backpex.Field.help_text(@field_options, assigns)}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
-        />
-      </Layout.field_container>
-    </div>
-    """
-  end
-
-  @impl Backpex.Field
-  def render_form_readonly(assigns) do
-    ~H"""
-    <div>
-      <Layout.field_container>
-        <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
-          <Layout.input_label text={@field_options[:label]} />
-        </:label>
-        <BackpexForm.input
-          type="textarea"
-          field={@form[@name]}
-          placeholder={@field_options[:placeholder]}
-          rows={@field_options[:rows]}
-          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
-          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
-          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
-          readonly
-          disabled
+          readonly={@readonly}
+          disabled={@readonly}
         />
       </Layout.field_container>
     </div>

--- a/lib/backpex/fields/time.ex
+++ b/lib/backpex/fields/time.ex
@@ -85,28 +85,8 @@ defmodule Backpex.Fields.Time do
           help_text={Backpex.Field.help_text(@field_options, assigns)}
           phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
           phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
-        />
-      </Layout.field_container>
-    </div>
-    """
-  end
-
-  @impl Backpex.Field
-  def render_form_readonly(assigns) do
-    ~H"""
-    <div>
-      <Layout.field_container>
-        <:label align={Backpex.Field.align_label(@field_options, assigns, :top)}>
-          <Layout.input_label text={@field_options[:label]} />
-        </:label>
-        <BackpexForm.input
-          type="time"
-          field={@form[@name]}
-          translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
-          phx-debounce={Backpex.Field.debounce(@field_options, assigns)}
-          phx-throttle={Backpex.Field.throttle(@field_options, assigns)}
-          readonly
-          disabled
+          readonly={@readonly}
+          disabled={@readonly}
         />
       </Layout.field_container>
     </div>

--- a/lib/backpex/html/resource.ex
+++ b/lib/backpex/html/resource.ex
@@ -150,6 +150,7 @@ defmodule Backpex.HTML.Resource do
       |> assign(:field, field)
       |> assign(:field_options, field_options)
       |> assign(:type, :form)
+      |> assign(:readonly, Backpex.Field.readonly?(field_options, assigns))
 
     ~H"""
     <.live_component


### PR DESCRIPTION
You can mark a field as read-only. In our field implementations, we have a dedicated `render_form_readonly/1` callback that returns read-only markup. This is simply a copy of the normal `render_form` version with some additional attributes. This MR passes a `readonly` assign to `render_form` to render these attributes conditionally. You would need to handle a read-only state in the same way for `render_index_form`.

With this change we can remove some duplicated code.

In case you have a more complex read-only version, e.g. in custom fields, you can just pattern match and define a dedicated function like before:

```elixir
@impl Backpex.Field
def render_form(%{readonly: true} = assigns) do
# read-only version
end

def render_form(assigns) do
# normal version
end
```

## Todos

- [x] Remove `render_form_readonly` callback from field
- [x] Refactor fields
- [x] Update documentation
- [x] Add upgrade guide


