### PR TITLE
Fix index edit not shown behind resource action modal

### DIFF
--- a/lib/backpex/field.ex
+++ b/lib/backpex/field.ex
@@ -321,7 +321,7 @@ defmodule Backpex.Field do
   def index_editable_enabled?(field_options, assigns, default \\ false)
 
   def index_editable_enabled?(_field_options, %{live_action: live_action}, _default)
-      when live_action != :index do
+      when live_action not in [:index, :resource_action] do
     false
   end
 


### PR DESCRIPTION
If the index view had editable fields, the layout would shift when the resource action modal was opened because the inputs were only shown for `:index` `live_action`, not `:resource_action`.

See the upload action in the latest demo: https://demo.backpex.live/admin/users