### PR TITLE
Fix entries were excluded from index view under certain conditions

### DIFF
--- a/lib/backpex/adapters/ecto.ex
+++ b/lib/backpex/adapters/ecto.ex
@@ -135,6 +135,8 @@ defmodule Backpex.Adapters.Ecto do
 
   def apply_search(query, _schema, nil, {_search_string, []}), do: query
 
+  def apply_search(query, _schema, nil, {"", _searchable_fields}), do: query
+
   def apply_search(query, _schema, nil, {search_string, searchable_fields}) do
     search_string = "%#{search_string}%"
 

--- a/test/adapters/ecto_test.exs
+++ b/test/adapters/ecto_test.exs
@@ -100,8 +100,7 @@ defmodule Backpex.Adapters.EctoTest do
     end
 
     test "adds tsquery fragment for non-empty search string" do
-      schema_alias = EctoAdapter.name_by_schema(TestUser)
-      base_query = from(TestUser, as: ^schema_alias)
+      base_query = from(TestUser, as: ^EctoAdapter.name_by_schema(TestUser))
 
       query = EctoAdapter.apply_search(base_query, TestUser, :title, {"hello world", []})
 

--- a/test/adapters/ecto_test.exs
+++ b/test/adapters/ecto_test.exs
@@ -1,0 +1,117 @@
+defmodule Backpex.Adapters.EctoTest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Query
+
+  alias Backpex.Adapters.Ecto, as: EctoAdapter
+
+  defmodule TestUser do
+    use Ecto.Schema
+
+    @primary_key {:id, :id, autogenerate: false}
+    schema "users" do
+      field :title, :string
+      field :name, :string
+    end
+  end
+
+  describe "apply_search/4 (without full text search configured)" do
+    test "adds ilike condition for one field" do
+      base_query = from(TestUser, as: ^EctoAdapter.name_by_schema(TestUser))
+
+      searchable_fields = [
+        {:title, %{module: Backpex.Fields.Text, queryable: TestUser}}
+      ]
+
+      query = EctoAdapter.apply_search(base_query, TestUser, nil, {"foo", searchable_fields})
+
+      assert [%{expr: ilike_expr}] = query.wheres
+      assert match?({:ilike, _, _}, ilike_expr)
+
+      expr_str = Macro.to_string(ilike_expr)
+      assert expr_str =~ "title"
+    end
+
+    test "chains ilike conditions with OR for multiple fields" do
+      base_query = from(TestUser, as: ^EctoAdapter.name_by_schema(TestUser))
+
+      searchable_fields = [
+        {:title, %{module: Backpex.Fields.Text, queryable: TestUser}},
+        {:name, %{module: Backpex.Fields.Text, queryable: TestUser}}
+      ]
+
+      query = EctoAdapter.apply_search(base_query, TestUser, nil, {"bar", searchable_fields})
+
+      assert [%{expr: or_expr}] = query.wheres
+      assert match?({:or, _, _}, or_expr)
+
+      expr_str = Macro.to_string(or_expr)
+      assert expr_str =~ "title"
+      assert expr_str =~ "name"
+    end
+
+    test "returns original query when no searchable fields provided" do
+      base_query = from(TestUser, as: ^EctoAdapter.name_by_schema(TestUser))
+
+      query = EctoAdapter.apply_search(base_query, TestUser, nil, {"baz", []})
+
+      assert query == base_query
+    end
+
+    test "returns original query when empty search string provided" do
+      base_query = from(TestUser, as: ^EctoAdapter.name_by_schema(TestUser))
+
+      searchable_fields = [
+        {:title, %{module: Backpex.Fields.Text, queryable: TestUser}}
+      ]
+
+      query = EctoAdapter.apply_search(base_query, TestUser, nil, {"", searchable_fields})
+
+      assert query == base_query
+    end
+
+    test "uses provided select expression for ilike" do
+      base_query = from(TestUser, as: ^EctoAdapter.name_by_schema(TestUser))
+
+      select_expr = dynamic([testuser: u], fragment("UPPER(?)", field(u, ^:name)))
+
+      searchable_fields = [
+        {:name_display, %{module: Backpex.Fields.Text, select: select_expr}}
+      ]
+
+      query = EctoAdapter.apply_search(base_query, TestUser, nil, {"qux", searchable_fields})
+
+      assert [%{expr: ilike_expr}] = query.wheres
+      assert match?({:ilike, _, _}, ilike_expr)
+
+      expr_str = Macro.to_string(ilike_expr)
+      assert expr_str =~ "fragment"
+      assert expr_str =~ "UPPER("
+    end
+  end
+
+  describe "apply_search/4 (with full text search configured)" do
+    test "returns original query on empty search string" do
+      base_query = from(TestUser)
+
+      query = EctoAdapter.apply_search(base_query, TestUser, :title, {"", []})
+
+      assert query == base_query
+    end
+
+    test "adds tsquery fragment for non-empty search string" do
+      schema_alias = EctoAdapter.name_by_schema(TestUser)
+      base_query = from(TestUser, as: ^schema_alias)
+
+      query = EctoAdapter.apply_search(base_query, TestUser, :title, {"hello world", []})
+
+      assert [%{expr: fragment_expr}] = query.wheres
+      assert match?({:fragment, _, _}, fragment_expr)
+
+      expr_str = Macro.to_string(fragment_expr)
+      assert expr_str =~ "websearch_to_tsquery"
+      assert expr_str =~ "@@"
+      assert expr_str =~ "title"
+    end
+  end
+end


### PR DESCRIPTION
closes #562 

We did not skip applying the search conditions if the search string was empty (`""`).

This resulted in conditions such as `ilike(a0.city, "%%")`being applied. While this was OK for string values, it excluded `NULL` values.

The solution is to skip applying search conditions when the search string is empty.

The fix can be tested by making the `address.city` field nullable and disabling search for all `adress` fields except for the `city` field.