### PR TITLE
Add missing `handle_info/2` function on index view

### DIFF
--- a/lib/backpex/live_resource/form.ex
+++ b/lib/backpex/live_resource/form.ex
@@ -49,6 +49,10 @@ defmodule Backpex.LiveResource.Form do
     |> noreply()
   end
 
+  def handle_info(_event, socket) do
+    noreply(socket)
+  end
+
   def handle_event(_event, _params, socket) do
     noreply(socket)
   end

--- a/lib/backpex/live_resource/index.ex
+++ b/lib/backpex/live_resource/index.ex
@@ -71,6 +71,22 @@ defmodule Backpex.LiveResource.Index do
     |> noreply()
   end
 
+  def handle_info({:update_changeset, changeset}, socket) do
+    socket
+    |> assign(:changeset, changeset)
+    |> noreply()
+  end
+
+  def handle_info({:put_assoc, {key, value} = _assoc}, socket) do
+    changeset = Ecto.Changeset.put_assoc(socket.assigns.changeset, key, value)
+    assocs = Map.get(socket.assigns, :assocs, []) |> Keyword.put(key, value)
+
+    socket
+    |> assign(:assocs, assocs)
+    |> assign(:changeset, changeset)
+    |> noreply()
+  end
+
   def handle_info(_event, socket) do
     noreply(socket)
   end


### PR DESCRIPTION
This is relevant for item actions with forms. See https://github.com/naymspace/backpex/blob/0.14.0/lib/backpex/live_components/form_component.ex#L99