### PR TITLE
Supress IgniterJs warnings when not installed

### DIFF
--- a/lib/mix/tasks/backpex.install.ex
+++ b/lib/mix/tasks/backpex.install.ex
@@ -61,6 +61,11 @@ if Code.ensure_loaded?(Igniter) do
     alias Igniter.Project.Module
     alias Igniter.Util.IO, as: IgniterIO
     alias Igniter.Util.Warning
+
+    # IgniterJs is an optional dependency - suppress warnings when not installed
+    @compile {:no_warn_undefined, {IgniterJs.Helpers, :read_and_validate_file, 1}}
+    @compile {:no_warn_undefined, {IgniterJs.Parsers.Javascript.Parser, :insert_imports, 3}}
+    @compile {:no_warn_undefined, {IgniterJs.Parsers.Javascript.Parser, :extend_hook_object, 3}}
     alias IgniterJs.Parsers.Javascript.Parser
 
     @default_app_css_path Path.join(["assets", "css", "app.css"])


### PR DESCRIPTION
Honestly, I'm completely unsure if this is correct way or if this should be merged. My only motivation is that I can't work on backpex without it as every file I edit in my project gets "==> backpex" at the top from `mix format` 🥹

I kind of thing that this might be bug in Mix, but as complete Elixir noob, I might be completely wrong.

Anyway, as IgniterJs is optional dependency I believe we shouldn't send warnings warnigns to output when it is missing.

Feel free to close this without merging, I'l simply leave it locally or install IgniterJs in my project. I just thought it might be helpful to somebody else.