### PR TITLE
Fix dropping readonly fields from change

### DIFF
--- a/lib/backpex/field.ex
+++ b/lib/backpex/field.ex
@@ -357,6 +357,21 @@ defmodule Backpex.Field do
   def readonly?(%{readonly: readonly}, assigns) when is_function(readonly, 1), do: readonly.(assigns)
   def readonly?(_field_options, _assigns), do: false
 
+  @doc """
+  Drops readonly field changes from the given change map.
+
+  Takes a map of string-keyed form params, a keyword list of field definitions,
+  and assigns. Returns the change map with readonly field keys removed.
+  """
+  def drop_readonly_changes(change, fields, assigns) do
+    read_only =
+      fields
+      |> Enum.filter(fn {_name, options} -> readonly?(options, assigns) end)
+      |> Enum.map(fn {name, _options} -> Atom.to_string(name) end)
+
+    Map.drop(change, read_only)
+  end
+
   def translate_error_fun(%{translate_error: translate_error}, _assigns) when is_function(translate_error, 1),
     do: translate_error
 

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -406,12 +406,7 @@ defmodule Backpex.FormComponent do
   end
 
   defp drop_readonly_changes(change, fields, assigns) do
-    read_only =
-      fields
-      |> Enum.filter(fn {_name, options} -> Backpex.Field.readonly?(options, assigns) end)
-      |> Enum.map(fn {name, _options} -> Atom.to_string(name) end)
-
-    Map.drop(change, read_only)
+    Backpex.Field.drop_readonly_changes(change, fields, assigns)
   end
 
   defp drop_unused_changes(change) do

--- a/lib/backpex/live_components/form_component.ex
+++ b/lib/backpex/live_components/form_component.ex
@@ -408,8 +408,8 @@ defmodule Backpex.FormComponent do
   defp drop_readonly_changes(change, fields, assigns) do
     read_only =
       fields
-      |> Enum.filter(&Backpex.Field.readonly?(&1, assigns))
-      |> Enum.map(&Atom.to_string(&1.name))
+      |> Enum.filter(fn {_name, options} -> Backpex.Field.readonly?(options, assigns) end)
+      |> Enum.map(fn {name, _options} -> Atom.to_string(name) end)
 
     Map.drop(change, read_only)
   end

--- a/test/field_test.exs
+++ b/test/field_test.exs
@@ -14,16 +14,12 @@ defmodule Backpex.FieldTest do
     end
   end
 
-  describe "readonly fields filtering" do
-    # This test mirrors the logic in Backpex.LiveComponents.FormComponent.drop_readonly_changes/3
-    # which is a private function. We test the same logic here to ensure readonly fields
-    # are properly filtered from form params before changeset creation.
-
+  describe "drop_readonly_changes/3" do
     test "readonly fields are correctly filtered from LiveResource fields" do
       fields = UpstreamPrices.fields()
       change = %{"name" => "Backpack", "upstream_price" => "100", "override_price" => "200"}
 
-      filtered = drop_readonly_changes(change, fields, %{})
+      filtered = Field.drop_readonly_changes(change, fields, %{})
 
       assert filtered == %{"name" => "Backpack", "override_price" => "200"}
       refute Map.has_key?(filtered, "upstream_price")
@@ -38,11 +34,11 @@ defmodule Backpex.FieldTest do
       change = %{"name" => "Test", "secret" => "hidden"}
 
       # As viewer - secret should be filtered
-      filtered = drop_readonly_changes(change, fields, %{role: :viewer})
+      filtered = Field.drop_readonly_changes(change, fields, %{role: :viewer})
       assert filtered == %{"name" => "Test"}
 
       # As admin - secret should remain
-      filtered = drop_readonly_changes(change, fields, %{role: :admin})
+      filtered = Field.drop_readonly_changes(change, fields, %{role: :admin})
       assert filtered == %{"name" => "Test", "secret" => "hidden"}
     end
   end
@@ -66,15 +62,5 @@ defmodule Backpex.FieldTest do
       assert Field.readonly?(%{readonly: readonly_fn}, %{role: :viewer}) == true
       assert Field.readonly?(%{readonly: readonly_fn}, %{role: :admin}) == false
     end
-  end
-
-  # Mirrors Backpex.LiveComponents.FormComponent.drop_readonly_changes/3
-  defp drop_readonly_changes(change, fields, assigns) do
-    read_only =
-      fields
-      |> Enum.filter(fn {_name, options} -> Field.readonly?(options, assigns) end)
-      |> Enum.map(fn {name, _options} -> Atom.to_string(name) end)
-
-    Map.drop(change, read_only)
   end
 end

--- a/test/field_test.exs
+++ b/test/field_test.exs
@@ -1,0 +1,80 @@
+defmodule Backpex.FieldTest do
+  use ExUnit.Case, async: true
+
+  alias Backpex.Field
+
+  # Simulates a LiveResource fields/0 callback structure
+  defmodule UpstreamPrices do
+    def fields do
+      [
+        name: %{module: Backpex.Fields.Text, label: "Name"},
+        upstream_price: %{module: Backpex.Fields.Number, label: "Upstream Price", readonly: true},
+        override_price: %{module: Backpex.Fields.Number, label: "Our Price"}
+      ]
+    end
+  end
+
+  describe "readonly fields filtering" do
+    # This test mirrors the logic in Backpex.LiveComponents.FormComponent.drop_readonly_changes/3
+    # which is a private function. We test the same logic here to ensure readonly fields
+    # are properly filtered from form params before changeset creation.
+
+    test "readonly fields are correctly filtered from LiveResource fields" do
+      fields = UpstreamPrices.fields()
+      change = %{"name" => "Backpack", "upstream_price" => "100", "override_price" => "200"}
+
+      filtered = drop_readonly_changes(change, fields, %{})
+
+      assert filtered == %{"name" => "Backpack", "override_price" => "200"}
+      refute Map.has_key?(filtered, "upstream_price")
+    end
+
+    test "readonly function field is filtered when condition is true" do
+      fields = [
+        name: %{module: Backpex.Fields.Text, label: "Name"},
+        secret: %{module: Backpex.Fields.Text, label: "Secret", readonly: fn assigns -> assigns[:role] == :viewer end}
+      ]
+
+      change = %{"name" => "Test", "secret" => "hidden"}
+
+      # As viewer - secret should be filtered
+      filtered = drop_readonly_changes(change, fields, %{role: :viewer})
+      assert filtered == %{"name" => "Test"}
+
+      # As admin - secret should remain
+      filtered = drop_readonly_changes(change, fields, %{role: :admin})
+      assert filtered == %{"name" => "Test", "secret" => "hidden"}
+    end
+  end
+
+  describe "readonly?/2" do
+    test "returns true for boolean true" do
+      assert Field.readonly?(%{readonly: true}, %{}) == true
+    end
+
+    test "returns false for boolean false" do
+      assert Field.readonly?(%{readonly: false}, %{}) == false
+    end
+
+    test "returns false when readonly key is missing" do
+      assert Field.readonly?(%{}, %{}) == false
+    end
+
+    test "evaluates function against assigns" do
+      readonly_fn = fn assigns -> assigns[:role] == :viewer end
+
+      assert Field.readonly?(%{readonly: readonly_fn}, %{role: :viewer}) == true
+      assert Field.readonly?(%{readonly: readonly_fn}, %{role: :admin}) == false
+    end
+  end
+
+  # Mirrors Backpex.LiveComponents.FormComponent.drop_readonly_changes/3
+  defp drop_readonly_changes(change, fields, assigns) do
+    read_only =
+      fields
+      |> Enum.filter(fn {_name, options} -> Field.readonly?(options, assigns) end)
+      |> Enum.map(fn {name, _options} -> Atom.to_string(name) end)
+
+    Map.drop(change, read_only)
+  end
+end


### PR DESCRIPTION
When experimenting with AshBackpex, I found out that :readonly fields aren't correctly dropped from a Change.

As I have :update action which accepts only some of fields, I need this working. Only alternative would be to omit read only fields from edit form which doesn't suit my use case.

I also added simple tests for this, but I don't really know how to test this correctly with existing tests structure. For now, I used dirty workaround and copied private `drop_readonly_changes` function directly to tests, just so I can test if it works.

But I think better (not ideal) way would be making the `drop_readonly_changes` non-private and add `@doc false`. Are you OK with that? Ideal would be probably to setup some "infrastructure" for LiveView and check whole process, but I'm not even sure where to begin with that.