### PR TITLE
Show validation errors for `Backpex.Fields.InlineCRUD`

### DIFF
--- a/lib/backpex/fields/inline_crud.ex
+++ b/lib/backpex/fields/inline_crud.ex
@@ -104,8 +104,7 @@ defmodule Backpex.Fields.InlineCRUD do
   end
 
   defp apply_action(socket, :form) do
-    socket
-    |> assign_form_errors()
+    assign_form_errors(socket)
   end
 
   defp apply_action(socket, _type), do: socket

--- a/lib/backpex/fields/inline_crud.ex
+++ b/lib/backpex/fields/inline_crud.ex
@@ -108,7 +108,7 @@ defmodule Backpex.Fields.InlineCRUD do
     |> assign_form_errors()
   end
 
-  defp apply_action(socket, _), do: socket
+  defp apply_action(socket, _type), do: socket
 
   defp validated_fields(fields, parent_name) do
     fields

--- a/lib/backpex/fields/inline_crud.ex
+++ b/lib/backpex/fields/inline_crud.ex
@@ -99,9 +99,16 @@ defmodule Backpex.Fields.InlineCRUD do
     socket
     |> assign(assigns)
     |> assign(child_fields: child_fields)
-    |> assign_form_errors()
+    |> apply_action(assigns.type)
     |> ok()
   end
+
+  defp apply_action(socket, :form) do
+    socket
+    |> assign_form_errors()
+  end
+
+  defp apply_action(socket, _), do: socket
 
   defp validated_fields(fields, parent_name) do
     fields

--- a/lib/backpex/fields/inline_crud.ex
+++ b/lib/backpex/fields/inline_crud.ex
@@ -85,6 +85,7 @@ defmodule Backpex.Fields.InlineCRUD do
       end
   """
   use Backpex.Field, config_schema: @config_schema
+
   require Backpex
 
   @impl Phoenix.LiveComponent
@@ -98,6 +99,7 @@ defmodule Backpex.Fields.InlineCRUD do
     socket
     |> assign(assigns)
     |> assign(child_fields: child_fields)
+    |> assign_form_errors()
     |> ok()
   end
 
@@ -205,6 +207,8 @@ defmodule Backpex.Fields.InlineCRUD do
           class="btn btn-outline btn-sm btn-primary"
         />
 
+        <BackpexForm.error :for={msg <- @errors} class="mt-1">{msg}</BackpexForm.error>
+
         <%= if help_text = Backpex.Field.help_text(@field_options, assigns) do %>
           <Backpex.HTML.Form.help_text class="mt-1">{help_text}</Backpex.HTML.Form.help_text>
         <% end %>
@@ -226,4 +230,13 @@ defmodule Backpex.Fields.InlineCRUD do
   defp child_field_class(%{class: class} = _child_field_options, assigns) when is_function(class), do: class.(assigns)
   defp child_field_class(%{class: class} = _child_field_options, _assigns) when is_binary(class), do: class
   defp child_field_class(_child_field_options, _assigns), do: "flex-1"
+
+  defp assign_form_errors(socket) do
+    %{assigns: %{form: form, name: name, field_options: field_options}} = socket
+
+    errors = if Phoenix.Component.used_input?(form[name]), do: form[name].errors, else: []
+    translate_error_fun = Map.get(field_options, :translate_error, &Function.identity/1)
+
+    assign(socket, :errors, BackpexForm.translate_form_errors(errors, translate_error_fun))
+  end
 end


### PR DESCRIPTION
... not only for the child fields, but also for the main field itself. This is useful to validate constraints over all associated items at once. 

I have tried to make the error handling similar to the other fields, but found the complex ones which do not delegate this to a form widget a bit inconsistent with regard to error handling. Feel free to correct my approach here.