### PR TITLE
Allow defining layout in callback function

### DIFF
--- a/demo/lib/demo_web/live/address_live.ex
+++ b/demo/lib/demo_web/live/address_live.ex
@@ -6,8 +6,10 @@ defmodule DemoWeb.AddressLive do
       update_changeset: &Demo.Address.update_changeset/3,
       create_changeset: &Demo.Address.create_changeset/3
     ],
-    layout: {DemoWeb.Layouts, :admin},
     fluid?: true
+
+  @impl Backpex.LiveResource
+  def layout(_assigns), do: {DemoWeb.Layouts, :admin}
 
   @impl Backpex.LiveResource
   def singular_name, do: "Address"

--- a/demo/lib/demo_web/live/category_live.ex
+++ b/demo/lib/demo_web/live/category_live.ex
@@ -6,8 +6,10 @@ defmodule DemoWeb.CategoryLive do
       update_changeset: &Demo.Category.update_changeset/3,
       create_changeset: &Demo.Category.create_changeset/3
     ],
-    layout: {DemoWeb.Layouts, :admin},
     init_order: %{by: :name, direction: :asc}
+
+  @impl Backpex.LiveResource
+  def layout(_assigns), do: {DemoWeb.Layouts, :admin}
 
   @impl Backpex.LiveResource
   def singular_name, do: "Category"

--- a/demo/lib/demo_web/live/film_review_live.ex
+++ b/demo/lib/demo_web/live/film_review_live.ex
@@ -6,8 +6,10 @@ defmodule DemoWeb.FilmReviewLive do
       update_changeset: &Demo.FilmReview.update_changeset/3,
       create_changeset: &Demo.FilmReview.create_changeset/3
     ],
-    layout: {DemoWeb.Layouts, :admin},
     full_text_search: :generated_tsvector
+
+  @impl Backpex.LiveResource
+  def layout(_assigns), do: {DemoWeb.Layouts, :admin}
 
   @impl Backpex.LiveResource
   def singular_name, do: "Film Review"

--- a/demo/lib/demo_web/live/invoice_live.ex
+++ b/demo/lib/demo_web/live/invoice_live.ex
@@ -3,8 +3,10 @@ defmodule DemoWeb.InvoiceLive do
     adapter_config: [
       schema: Demo.Invoice,
       repo: Demo.Repo
-    ],
-    layout: {DemoWeb.Layouts, :admin}
+    ]
+
+  @impl Backpex.LiveResource
+  def layout(_assigns), do: {DemoWeb.Layouts, :admin}
 
   @impl Backpex.LiveResource
   def singular_name, do: "Invoice"

--- a/demo/lib/demo_web/live/post_live.ex
+++ b/demo/lib/demo_web/live/post_live.ex
@@ -6,11 +6,13 @@ defmodule DemoWeb.PostLive do
       update_changeset: &Demo.Post.update_changeset/3,
       create_changeset: &Demo.Post.create_changeset/3
     ],
-    layout: {DemoWeb.Layouts, :admin},
     fluid?: true,
     save_and_continue_button?: true
 
   import Ecto.Query, warn: false
+
+  @impl Backpex.LiveResource
+  def layout(_assigns), do: {DemoWeb.Layouts, :admin}
 
   @impl Backpex.LiveResource
   def singular_name, do: "Post"

--- a/demo/lib/demo_web/live/product_live.ex
+++ b/demo/lib/demo_web/live/product_live.ex
@@ -5,10 +5,12 @@ defmodule DemoWeb.ProductLive do
       repo: Demo.Repo,
       update_changeset: &Demo.Product.changeset/3,
       create_changeset: &Demo.Product.changeset/3
-    ],
-    layout: {DemoWeb.Layouts, :admin}
+    ]
 
   import Ecto.Query, warn: false
+
+  @impl Backpex.LiveResource
+  def layout(_assigns), do: {DemoWeb.Layouts, :admin}
 
   @impl Backpex.LiveResource
   def singular_name, do: "Product"

--- a/demo/lib/demo_web/live/short_link_live.ex
+++ b/demo/lib/demo_web/live/short_link_live.ex
@@ -8,8 +8,10 @@ defmodule DemoWeb.ShortLinkLive do
       update_changeset: &Demo.ShortLink.changeset/3,
       create_changeset: &Demo.ShortLink.changeset/3
     ],
-    primary_key: :short_key,
-    layout: {DemoWeb.Layouts, :admin}
+    primary_key: :short_key
+
+  @impl Backpex.LiveResource
+  def layout(_assigns), do: {DemoWeb.Layouts, :admin}
 
   @impl Backpex.LiveResource
   def singular_name, do: "Short Link"

--- a/demo/lib/demo_web/live/tag_live.ex
+++ b/demo/lib/demo_web/live/tag_live.ex
@@ -6,7 +6,6 @@ defmodule DemoWeb.TagLive do
       update_changeset: &Demo.Tag.update_changeset/3,
       create_changeset: &Demo.Tag.create_changeset/3
     ],
-    layout: {DemoWeb.Layouts, :admin},
     init_order: %{by: :name, direction: :desc},
     on_mount: __MODULE__
 
@@ -19,6 +18,9 @@ defmodule DemoWeb.TagLive do
 
     {:cont, Phoenix.LiveView.put_flash(socket, :info, msg)}
   end
+
+  @impl Backpex.LiveResource
+  def layout(_assigns), do: {DemoWeb.Layouts, :admin}
 
   @impl Backpex.LiveResource
   def singular_name, do: "Tag"

--- a/demo/lib/demo_web/live/user_live.ex
+++ b/demo/lib/demo_web/live/user_live.ex
@@ -8,10 +8,12 @@ defmodule DemoWeb.UserLive do
       create_changeset: &Demo.User.changeset/3,
       item_query: &__MODULE__.item_query/3
     ],
-    layout: &DemoWeb.Layouts.admin/1,
     init_order: &__MODULE__.init_order/1
 
   import Ecto.Query, warn: false
+
+  @impl Backpex.LiveResource
+  def layout(_assigns), do: {DemoWeb.Layouts, :admin}
 
   @impl Backpex.LiveResource
   def singular_name, do: "User"

--- a/guides/upgrading/v0.18.md
+++ b/guides/upgrading/v0.18.md
@@ -1,0 +1,55 @@
+# Upgrading to v0.18
+
+## Bump Your Deps
+
+Update Backpex to the latest version:
+
+```elixir
+defp deps do
+  [
+    {:backpex, "~> 0.18.0"}
+  ]
+end
+```
+
+## Move layout to callback (recommended)
+
+The `layout` option in `use Backpex.LiveResource` stores the layout module reference in a module attribute, which creates a compile-time dependency. In most Phoenix applications this leads to a compile cycle:
+
+```
+YourLive → YourLayouts → YourWeb (:html) → YourRouter → YourLive
+```
+
+This causes a change in any of these files to recompile all of them, slowing down development.
+
+To fix this, move the layout from the `use` option to the new `layout/1` callback:
+
+**Before:**
+
+```elixir
+defmodule MyAppWeb.PostLive do
+  use Backpex.LiveResource,
+    layout: {MyAppWeb.Layouts, :admin},
+    adapter_config: [...]
+end
+```
+
+**After:**
+
+```elixir
+defmodule MyAppWeb.PostLive do
+  use Backpex.LiveResource,
+    adapter_config: [...]
+
+  @impl Backpex.LiveResource
+  def layout(_assigns), do: {MyAppWeb.Layouts, :admin}
+end
+```
+
+The `layout` option continues to work, so this change is not required. However, we recommend migrating to the callback to avoid compile cycles.
+
+You can verify the improvement by running:
+
+```bash
+mix xref graph --format cycles --label compile-connected
+```

--- a/lib/backpex/html/layout.ex
+++ b/lib/backpex/html/layout.ex
@@ -15,13 +15,9 @@ defmodule Backpex.HTML.Layout do
   slot :inner_content
 
   def layout(assigns) do
-    if assigns.live_resource.config(:layout) do
-      case assigns.live_resource.config(:layout) do
-        {module, fun} -> apply(module, fun, [assigns])
-        fun when is_function(fun, 1) -> fun.(assigns)
-      end
-    else
-      assigns.live_resource.layout(assigns)
+    case assigns.live_resource.layout(assigns) do
+      {module, fun} -> apply(module, fun, [assigns])
+      fun when is_function(fun, 1) -> fun.(assigns)
     end
   end
 

--- a/lib/backpex/html/layout.ex
+++ b/lib/backpex/html/layout.ex
@@ -15,9 +15,13 @@ defmodule Backpex.HTML.Layout do
   slot :inner_content
 
   def layout(assigns) do
-    case assigns.live_resource.config(:layout) do
-      {module, fun} -> apply(module, fun, [assigns])
-      fun when is_function(fun, 1) -> fun.(assigns)
+    if assigns.live_resource.config(:layout) do
+      case assigns.live_resource.config(:layout) do
+        {module, fun} -> apply(module, fun, [assigns])
+        fun when is_function(fun, 1) -> fun.(assigns)
+      end
+    else
+      assigns.live_resource.layout(assigns)
     end
   end
 

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -189,7 +189,8 @@ defmodule Backpex.LiveResource do
   Defines the layout to be used by the LiveResource.
 
   Can be used instead of the `layout` option in `use Backpex.LiveResource` to avoid
-  compile-time dependencies on layout modules. By default, returns the value of the `layout` option.
+  compile-time dependencies on layout modules. By default, returns the value of the `layout` option
+  and raises if neither is configured.
 
   Must return either a `{module, function_name}` tuple or a function with arity 1.
   """
@@ -302,7 +303,17 @@ defmodule Backpex.LiveResource do
       def filters(_assigns), do: filters()
 
       @impl Backpex.LiveResource
-      def layout(_assigns), do: config(:layout)
+      def layout(_assigns) do
+        case config(:layout) do
+          nil ->
+            raise ArgumentError,
+                  "No layout configured for #{inspect(__MODULE__)}. " <>
+                    "Define a layout/1 callback in #{inspect(__MODULE__)}."
+
+          value ->
+            value
+        end
+      end
 
       @impl Backpex.LiveResource
       def resource_actions, do: []

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -186,10 +186,14 @@ defmodule Backpex.LiveResource do
   @callback filters(assigns :: map()) :: keyword()
 
   @doc """
-  This function can be used to provide the layout at runtime rather than compile-time via
-  the `layout` option in `use Backpex.LiveResource`
+  Defines the layout to be used by the LiveResource.
+
+  Can be used instead of the `layout` option in `use Backpex.LiveResource` to avoid
+  compile-time dependencies on layout modules. By default, returns the value of the `layout` option.
+
+  Must return either a `{module, function_name}` tuple or a function with arity 1.
   """
-  @callback layout(assigns :: map()) :: %Phoenix.LiveView.Rendered{}
+  @callback layout(assigns :: map()) :: {module(), atom()} | (map() -> Phoenix.LiveView.Rendered.t())
 
   @doc """
   A list of metrics shown on the index view of your resource.
@@ -298,7 +302,7 @@ defmodule Backpex.LiveResource do
       def filters(_assigns), do: filters()
 
       @impl Backpex.LiveResource
-      def layout(assigns), do: nil
+      def layout(_assigns), do: config(:layout)
 
       @impl Backpex.LiveResource
       def resource_actions, do: []

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -33,7 +33,8 @@ defmodule Backpex.LiveResource do
     layout: [
       doc: "Layout to be used by the LiveResource.",
       type: {:or, [:mod_arg, {:fun, 1}]},
-      required: false
+      required: false,
+      deprecated: "Use the layout/1 callback instead to avoid compile-time dependencies."
     ],
     pubsub: [
       doc: "PubSub configuration.",

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -33,7 +33,7 @@ defmodule Backpex.LiveResource do
     layout: [
       doc: "Layout to be used by the LiveResource.",
       type: {:or, [:mod_arg, {:fun, 1}]},
-      required: true
+      required: false
     ],
     pubsub: [
       doc: "PubSub configuration.",
@@ -186,6 +186,12 @@ defmodule Backpex.LiveResource do
   @callback filters(assigns :: map()) :: keyword()
 
   @doc """
+  This function can be used to provide the layout at runtime rather than compile-time via
+  the `layout` option in `use Backpex.LiveResource`
+  """
+  @callback layout(assigns :: map()) :: %Phoenix.LiveView.Rendered{}
+
+  @doc """
   A list of metrics shown on the index view of your resource.
   """
   @callback metrics() :: keyword()
@@ -292,6 +298,9 @@ defmodule Backpex.LiveResource do
       def filters(_assigns), do: filters()
 
       @impl Backpex.LiveResource
+      def layout(assigns), do: nil
+
+      @impl Backpex.LiveResource
       def resource_actions, do: []
 
       @impl Backpex.LiveResource
@@ -301,6 +310,7 @@ defmodule Backpex.LiveResource do
                      fields: 0,
                      filters: 0,
                      filters: 1,
+                     layout: 1,
                      resource_actions: 0,
                      item_actions: 1,
                      index_row_class: 4


### PR DESCRIPTION
Hello!

I was debugging some [compile cycles](https://hexdocs.pm/mix/main/Mix.Tasks.Xref.html) in a Phoenix application, and noticed that `backpex` was part of the issue.

The demo application has a good example of what I'm running into. If you run `mix xref graph --format cycles --label compile-connected`, it reports that there is a compile cycle:

```
demo/ $ mix xref graph --format cycles --label compile-connected
1 cycles found. Showing them in decreasing size:

Cycle of length 16 (9 compile, 1 export):

    lib/demo_web/components/core_components.ex
    lib/demo_web/components/layouts.ex (export)
    lib/demo_web/controllers/redirect_controller.ex
    lib/demo_web/endpoint.ex
    lib/demo_web/item_actions/user_soft_delete.ex
    lib/demo_web/live/address_live.ex (compile)
    lib/demo_web/live/category_live.ex (compile)
    lib/demo_web/live/film_review_live.ex (compile)
    lib/demo_web/live/invoice_live.ex (compile)
    lib/demo_web/live/post_live.ex (compile)
    lib/demo_web/live/product_live.ex (compile)
    lib/demo_web/live/short_link_live.ex (compile)
    lib/demo_web/live/tag_live.ex (compile)
    lib/demo_web/live/user_live.ex (compile)
    lib/demo_web/resource_actions/upload.ex
    lib/demo_web/router.ex
```

This results in a change in any of the files recompiling all of the files, which usually means slower compile times during development in apps that use Backpex.

I'm not deeply familiar with Elixir compiler functionality, but my understanding is the reason for it is the `DemoWeb.Layouts` becomes a compile dependency of the LiveViews when specified in `use Backpex.LiveResource`. `DemoWeb.Layouts` includes `use DemoWeb, :html` which ends up pulling in the router, etc.

To continue the above example using the demo app, if you apply [this patch](https://github.com/user-attachments/files/25243387/fix_compile_cycle.patch) to replace the layout option with the callback, the demo app no longer has a compile cycle:

```
demo/ $ mix xref graph --format cycles --label compile-connected
No cycles found
```

I'm proposing allowing specifying the layout as a callback function to avoid the specific compile dependency between layouts and the LiveView. To avoid a breaking change, I've not removed the current option. I also haven't tried updating any guides, documentation, or similar, but am happy to if you're open to this change.


