### PR TITLE
Fix text of alert messages does not change properly

### DIFF
--- a/lib/backpex/html/layout.ex
+++ b/lib/backpex/html/layout.ex
@@ -175,7 +175,7 @@ defmodule Backpex.HTML.Layout do
   attr :id, :string, doc: "the optional id of alert container"
   attr :flash, :map, default: %{}, doc: "the map of flash messages to display"
   attr :class, :string, default: nil, doc: "additional class to be added to the component"
-  attr :kind, :atom, values: ~w(info success warning error)a, doc: "used for styling"
+  attr :kind, :atom, required: true, values: ~w(info success warning error)a, doc: "used for styling"
   attr :closable, :boolean, default: true, doc: "show or hide the close button"
   attr :on_close, JS, default: nil, doc: "optional event triggered on alert close"
   attr :close_label, :string, default: "Close alert"

--- a/lib/backpex/html/layout.ex
+++ b/lib/backpex/html/layout.ex
@@ -133,13 +133,10 @@ defmodule Backpex.HTML.Layout do
     <div aria-live="polite">
       <.alert
         :for={kind <- ~w(info success warning error)a}
-        :if={msg = Phoenix.Flash.get(@flash, kind)}
         kind={kind}
+        flash={@flash}
         close_label={@close_label}
-        on_close={JS.push("lv:clear-flash", value: %{key: kind})}
-      >
-        {msg}
-      </.alert>
+      />
       <div class="toast toast-end toast-top z-50">
         <.alert
           id="client-error"
@@ -175,10 +172,12 @@ defmodule Backpex.HTML.Layout do
   """
   @doc type: :component
 
+  attr :id, :string, doc: "the optional id of alert container"
+  attr :flash, :map, default: %{}, doc: "the map of flash messages to display"
   attr :class, :string, default: nil, doc: "additional class to be added to the component"
   attr :kind, :atom, values: ~w(info success warning error)a, doc: "used for styling"
   attr :closable, :boolean, default: true, doc: "show or hide the close button"
-  attr :on_close, JS, default: %JS{}, doc: "event triggered on alert close"
+  attr :on_close, JS, default: nil, doc: "optional event triggered on alert close"
   attr :close_label, :string, default: "Close alert"
   attr :title, :string, default: nil, doc: "title for the alert"
   attr :rest, :global
@@ -186,8 +185,12 @@ defmodule Backpex.HTML.Layout do
   slot :icon
 
   def alert(assigns) do
+    assigns = assign_new(assigns, :id, fn -> "flash-#{assigns.kind}" end)
+
     ~H"""
     <div
+      :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
+      id={@id}
       class={[
         "alert my-4",
         @kind === :info && "alert-info",
@@ -197,7 +200,7 @@ defmodule Backpex.HTML.Layout do
         @class
       ]}
       role="alert"
-      data-close={@on_close}
+      data-close={@on_close || JS.push("lv:clear-flash", value: %{key: @kind})}
       {@rest}
     >
       <%= if @icon == [] do %>
@@ -210,7 +213,7 @@ defmodule Backpex.HTML.Layout do
       <% end %>
       <div>
         <h3 :if={@title} class="font-bold">{@title}</h3>
-        <div>{render_slot(@inner_block)}</div>
+        <div>{msg}</div>
       </div>
       <div :if={@closable}>
         <button

--- a/lib/backpex/html/layout.ex
+++ b/lib/backpex/html/layout.ex
@@ -172,7 +172,7 @@ defmodule Backpex.HTML.Layout do
   """
   @doc type: :component
 
-  attr :id, :string, doc: "the optional id of alert container"
+  attr :id, :string, doc: "optional id of the alert container; when not provided, a default of \"flash-<kind>\" is used"
   attr :flash, :map, default: %{}, doc: "the map of flash messages to display"
   attr :class, :string, default: nil, doc: "additional class to be added to the component"
   attr :kind, :atom, required: true, values: ~w(info success warning error)a, doc: "used for styling"


### PR DESCRIPTION
 - Fix flash message text not updating when switching between flash kinds (e.g. success → error) by moving the flash resolution and conditional rendering into the alert component itself
 - Add a stable id per flash kind so LiveView can properly track DOM elements across re-renders
 - Make alert self-contained: it now accepts a flash map, resolves the message internally, and defaults on_close to clear the matching flash key

Based on 
- https://github.com/phoenixframework/phoenix/blob/v1.8.3/installer/templates/phx_web/components/layouts.ex#L85
- https://github.com/phoenixframework/phoenix/blob/v1.8.3/installer/templates/phx_web/components/core_components.ex#L50