### PR TITLE
Fix BelongsTo index edit select picker inheriting error background color

### DIFF
--- a/lib/backpex/fields/belongs_to.ex
+++ b/lib/backpex/fields/belongs_to.ex
@@ -181,7 +181,8 @@ defmodule Backpex.Fields.BelongsTo do
           input_class={[
             "select select-sm",
             @valid && "not-hover:select-ghost",
-            !@valid && "select-error text-error-content bg-error/10"
+            !@valid &&
+              "select-error text-error-content bg-error/10 [&.select::picker(select)]:bg-base-100 [&.select::picker(select)]:text-base-content"
           ]}
           disabled={@readonly}
           hide_errors


### PR DESCRIPTION
Add CSS rules so the native select picker keeps base background and text colors when the field is invalid