### PR TITLE
Fix `sort_by` not working in `HasManyThrough` field

### DIFF
--- a/lib/backpex/fields/has_many_through.ex
+++ b/lib/backpex/fields/has_many_through.ex
@@ -522,7 +522,7 @@ defmodule Backpex.Fields.HasManyThrough do
     end)
   end
 
-  defp maybe_sort_by([%{child: _child} | _tail] = items, %{field: %{sort_by: column_names}} = _assigns) do
+  defp maybe_sort_by([%{child: _child} | _tail] = items, %{field_options: %{sort_by: column_names}} = _assigns) do
     items
     |> Enum.sort_by(fn item ->
       column_names


### PR DESCRIPTION
The `maybe_sort_by` function matched on `assigns.field` which is a tuple `{name, field_options}`, not a map. This caused the pattern match to always fail, falling through to the catch-all clause that returns items unsorted. Match on `assigns.field_options` instead.