### PR TITLE
Add optional `link/2` callback to ItemActions

### DIFF
--- a/demo/test/demo_web/live/film_review/index_live_test.exs
+++ b/demo/test/demo_web/live/film_review/index_live_test.exs
@@ -54,7 +54,7 @@ defmodule DemoWeb.Live.FilmReview.IndexLiveTest do
 
       conn
       |> visit(~p"/admin/film-reviews")
-      |> assert_has("button[aria-label='Show'][phx-value-item-id='#{film_review.id}']")
+      |> assert_has("#item-action-show-#{film_review.id}")
     end
 
     test "edit action is available", %{conn: conn} do
@@ -62,7 +62,7 @@ defmodule DemoWeb.Live.FilmReview.IndexLiveTest do
 
       conn
       |> visit(~p"/admin/film-reviews")
-      |> assert_has("button[aria-label='Edit'][phx-value-item-id='#{film_review.id}']")
+      |> assert_has("#item-action-edit-#{film_review.id}")
     end
   end
 

--- a/demo/test/demo_web/live/invoice/index_live_test.exs
+++ b/demo/test/demo_web/live/invoice/index_live_test.exs
@@ -34,7 +34,7 @@ defmodule DemoWeb.Live.Invoice.IndexLiveTest do
     test "no edit action available", %{conn: conn, invoices: [invoice | _]} do
       conn
       |> visit(~p"/admin/invoices")
-      |> refute_has("button[aria-label='Edit'][phx-value-item-id='#{invoice.id}']")
+      |> refute_has("#item-action-edit-#{invoice.id}")
     end
 
     test "no delete action available", %{conn: conn, invoices: [invoice | _]} do
@@ -47,7 +47,7 @@ defmodule DemoWeb.Live.Invoice.IndexLiveTest do
       conn
       |> visit(~p"/admin/invoices")
       # Show action is not available because routes are only: [:index]
-      |> refute_has("button[aria-label='Show'][phx-value-item-id='#{invoice.id}']")
+      |> refute_has("#item-action-show-#{invoice.id}")
     end
 
     test "currency field formats amount correctly", %{conn: conn} do

--- a/demo/test/support/live_resource_tests.ex
+++ b/demo/test/support/live_resource_tests.ex
@@ -65,7 +65,7 @@ defmodule Demo.Support.LiveResourceTests do
       |> visit(base_path)
       |> unwrap(fn view ->
         view
-        |> element("button[aria-label='Show'][phx-value-item-id='#{first_item_id}']")
+        |> element("#item-action-show-#{first_item_id}")
         |> render_click()
       end)
       |> assert_path("#{base_path}/#{first_item_id}/show")
@@ -91,7 +91,7 @@ defmodule Demo.Support.LiveResourceTests do
       |> visit(base_path)
       |> unwrap(fn view ->
         view
-        |> element("button[aria-label='Edit'][phx-value-item-id='#{first_item_id}']")
+        |> element("#item-action-edit-#{first_item_id}")
         |> render_click()
       end)
       |> assert_path("#{base_path}/#{first_item_id}/edit")
@@ -115,7 +115,7 @@ defmodule Demo.Support.LiveResourceTests do
       |> assert_has("td", text: old_value, exact: true)
       |> unwrap(fn view ->
         view
-        |> element("button[aria-label='Edit'][phx-value-item-id='#{item.id}']")
+        |> element("#item-action-edit-#{item.id}")
         |> render_click()
       end)
       |> assert_path("#{base_path}/#{item.id}/edit")
@@ -146,7 +146,7 @@ defmodule Demo.Support.LiveResourceTests do
       |> assert_has("td", text: display_value, exact: true)
       |> unwrap(fn view ->
         view
-        |> element("button[aria-label='Edit'][phx-value-item-id='#{item.id}']")
+        |> element("#item-action-edit-#{item.id}")
         |> render_click()
       end)
       |> assert_path("#{base_path}/#{item.id}/edit")

--- a/lib/backpex/html/resource/resource_index_table.html.heex
+++ b/lib/backpex/html/resource/resource_index_table.html.heex
@@ -66,9 +66,20 @@
         "text-base-content/75 z-10 w-0 px-6"
       ]}>
         <div class={["flex items-center justify-end space-x-2"]}>
+          <.link
+            :for={{key, action} <- filter_item_actions(@item_actions, :row)}
+            :if={Backpex.ItemAction.has_link?(action) and @live_resource.can?(assigns, key, item)}
+            id={"item-action-#{key}-#{LiveResource.primary_value(item, @live_resource)}"}
+            navigate={action.module.link(assigns, item)}
+            aria-label={action.module.label(assigns, item)}
+            phx-hook="BackpexTooltip"
+            data-tooltip={action.module.label(assigns, item)}
+          >
+            {action.module.icon(assigns, item)}
+          </.link>
           <button
             :for={{key, action} <- filter_item_actions(@item_actions, :row)}
-            :if={@live_resource.can?(assigns, key, item)}
+            :if={not Backpex.ItemAction.has_link?(action) and @live_resource.can?(assigns, key, item)}
             id={"item-action-#{key}-#{LiveResource.primary_value(item, @live_resource)}"}
             type="button"
             phx-click="item-action"

--- a/lib/backpex/html/resource/resource_index_table.html.heex
+++ b/lib/backpex/html/resource/resource_index_table.html.heex
@@ -66,31 +66,33 @@
         "text-base-content/75 z-10 w-0 px-6"
       ]}>
         <div class={["flex items-center justify-end space-x-2"]}>
-          <.link
-            :for={{key, action} <- filter_item_actions(@item_actions, :row)}
-            :if={Backpex.ItemAction.has_link?(action) and @live_resource.can?(assigns, key, item)}
-            id={"item-action-#{key}-#{LiveResource.primary_value(item, @live_resource)}"}
-            navigate={action.module.link(assigns, item)}
-            aria-label={action.module.label(assigns, item)}
-            phx-hook="BackpexTooltip"
-            data-tooltip={action.module.label(assigns, item)}
-          >
-            {action.module.icon(assigns, item)}
-          </.link>
-          <button
-            :for={{key, action} <- filter_item_actions(@item_actions, :row)}
-            :if={not Backpex.ItemAction.has_link?(action) and @live_resource.can?(assigns, key, item)}
-            id={"item-action-#{key}-#{LiveResource.primary_value(item, @live_resource)}"}
-            type="button"
-            phx-click="item-action"
-            phx-value-action-key={key}
-            phx-value-item-id={LiveResource.primary_value(item, @live_resource)}
-            aria-label={action.module.label(assigns, item)}
-            phx-hook="BackpexTooltip"
-            data-tooltip={action.module.label(assigns, item)}
-          >
-            {action.module.icon(assigns, item)}
-          </button>
+          <%= for {key, action} <- filter_item_actions(@item_actions, :row),
+                  @live_resource.can?(assigns, key, item) do %>
+            <%= if Backpex.ItemAction.has_link?(action) do %>
+              <.link
+                id={"item-action-#{key}-#{LiveResource.primary_value(item, @live_resource)}"}
+                navigate={action.module.link(assigns, item)}
+                aria-label={action.module.label(assigns, item)}
+                phx-hook="BackpexTooltip"
+                data-tooltip={action.module.label(assigns, item)}
+              >
+                {action.module.icon(assigns, item)}
+              </.link>
+            <% else %>
+              <button
+                id={"item-action-#{key}-#{LiveResource.primary_value(item, @live_resource)}"}
+                type="button"
+                phx-click="item-action"
+                phx-value-action-key={key}
+                phx-value-item-id={LiveResource.primary_value(item, @live_resource)}
+                aria-label={action.module.label(assigns, item)}
+                phx-hook="BackpexTooltip"
+                data-tooltip={action.module.label(assigns, item)}
+              >
+                {action.module.icon(assigns, item)}
+              </button>
+            <% end %>
+          <% end %>
         </div>
       </td>
     </tr>

--- a/lib/backpex/item_actions/edit.ex
+++ b/lib/backpex/item_actions/edit.ex
@@ -21,6 +21,17 @@ defmodule Backpex.ItemActions.Edit do
   def label(assigns, _item), do: Backpex.__("Edit", assigns.live_resource)
 
   @impl Backpex.ItemAction
+  def link(assigns, item) do
+    query_params =
+      case Map.get(assigns, :return_to) do
+        nil -> %{}
+        return_to -> %{return_to: return_to}
+      end
+
+    Router.get_path(assigns.socket, assigns.live_resource, assigns.params, :edit, item, query_params)
+  end
+
+  @impl Backpex.ItemAction
   def handle(socket, [item | _items], _data) do
     query_params =
       case Map.get(socket.assigns, :return_to) do

--- a/lib/backpex/item_actions/edit.ex
+++ b/lib/backpex/item_actions/edit.ex
@@ -30,17 +30,4 @@ defmodule Backpex.ItemActions.Edit do
 
     Router.get_path(assigns.socket, assigns.live_resource, assigns.params, :edit, item, query_params)
   end
-
-  @impl Backpex.ItemAction
-  def handle(socket, [item | _items], _data) do
-    query_params =
-      case Map.get(socket.assigns, :return_to) do
-        nil -> %{}
-        return_to -> %{return_to: return_to}
-      end
-
-    path = Router.get_path(socket, socket.assigns.live_resource, socket.assigns.params, :edit, item, query_params)
-
-    {:ok, Phoenix.LiveView.push_navigate(socket, to: path)}
-  end
 end

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -115,20 +115,7 @@ defmodule Backpex.ItemAction do
   end
 
   defmacro __before_compile__(env) do
-    handle_function? = Module.defines?(env.module, {:handle, 3})
-    link_function? = Module.defines?(env.module, {:link, 2})
-
-    if not handle_function? and not link_function? do
-      raise CompileError,
-        file: env.file,
-        line: env.line,
-        description: """
-        ItemAction #{inspect(env.module)} must implement at least one of handle/3 or link/2.
-
-        Implement handle/3 for actions that perform server-side operations,
-        or link/2 for actions that navigate to a URL.
-        """
-    end
+    validate_handle_or_link!(env)
 
     quote do
       @after_compile Backpex.ItemAction
@@ -185,6 +172,39 @@ defmodule Backpex.ItemAction do
     else
       # fields/0 is not defined, which means it will use the default empty list
       :ok
+    end
+  end
+
+  defp validate_handle_or_link!(env) do
+    handle_function? = Module.defines?(env.module, {:handle, 3})
+    link_function? = Module.defines?(env.module, {:link, 2})
+
+    cond do
+      not handle_function? and not link_function? ->
+        raise CompileError,
+          file: env.file,
+          line: env.line,
+          description: """
+          ItemAction #{inspect(env.module)} must implement either handle/3 or link/2.
+
+          Implement handle/3 for actions that perform server-side operations,
+          or link/2 for actions that navigate to a URL.
+          """
+
+      handle_function? and link_function? ->
+        raise CompileError,
+          file: env.file,
+          line: env.line,
+          description: """
+          ItemAction #{inspect(env.module)} implements both handle/3 and link/2.
+
+          An item action must implement exactly one of these callbacks.
+          Use handle/3 for actions that perform server-side operations,
+          or link/2 for actions that navigate to a URL.
+          """
+
+      true ->
+        :ok
     end
   end
 

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -84,8 +84,8 @@ defmodule Backpex.ItemAction do
   @doc """
   Performs the action. It takes the socket, the list of affected items, and the casted and validated data (received from [`Ecto.Changeset.apply_action/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
 
-  This callback is optional when `c:link/2` is implemented (link-based actions navigate directly without a server round-trip).
-  An item action must implement at least one of `c:handle/3` or `c:link/2`.
+  Exactly one of `c:handle/3` or `c:link/2` must be implemented for each item action.
+  If `c:link/2` is implemented, `c:handle/3` must not be defined, and vice versa. Link-based actions navigate directly without a server round-trip.
 
   You must return either `{:ok, socket}` or `{:error, changeset}`.
 

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -212,7 +212,7 @@ defmodule Backpex.ItemAction do
   def has_link?(item_action) do
     module = Map.fetch!(item_action, :module)
 
-    function_exported?(module, :link, 2)
+    Code.ensure_loaded?(module) and function_exported?(module, :link, 2)
   end
 
   @doc """

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -58,6 +58,13 @@ defmodule Backpex.ItemAction do
   @callback label(assigns :: map(), item :: struct() | nil) :: binary()
 
   @doc """
+  Returns a URL path for the item action. When implemented, the action renders as a `<.link navigate={path}>`
+  instead of a `<button>`. This enables standard browser link behavior such as Ctrl+click to open in a new tab
+  and right-click context menus.
+  """
+  @callback link(assigns :: map(), item :: struct()) :: binary()
+
+  @doc """
   Confirm button label
   """
   @callback confirm_label(assigns :: map()) :: binary()
@@ -90,7 +97,7 @@ defmodule Backpex.ItemAction do
   @callback handle(socket :: Phoenix.LiveView.Socket.t(), items :: list(map()), params :: map() | struct()) ::
               {:ok, Phoenix.LiveView.Socket.t()} | {:error, Ecto.Changeset.t()}
 
-  @optional_callbacks confirm: 1, confirm_label: 1, cancel_label: 1, changeset: 3, fields: 0
+  @optional_callbacks confirm: 1, confirm_label: 1, cancel_label: 1, changeset: 3, fields: 0, link: 2
 
   @doc """
   Defines `Backpex.ItemAction` behaviour and provides default implementations.
@@ -179,6 +186,15 @@ defmodule Backpex.ItemAction do
     module = Map.fetch!(item_action, :module)
 
     module.fields() != []
+  end
+
+  @doc """
+  Checks whether item action has a link callback.
+  """
+  def has_link?(item_action) do
+    module = Map.fetch!(item_action, :module)
+
+    function_exported?(module, :link, 2)
   end
 
   @doc """

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -84,6 +84,9 @@ defmodule Backpex.ItemAction do
   @doc """
   Performs the action. It takes the socket, the list of affected items, and the casted and validated data (received from [`Ecto.Changeset.apply_action/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#apply_action/2)).
 
+  This callback is optional when `c:link/2` is implemented (link-based actions navigate directly without a server round-trip).
+  An item action must implement at least one of `c:handle/3` or `c:link/2`.
+
   You must return either `{:ok, socket}` or `{:error, changeset}`.
 
   If `{:ok, socket}` is returned, the action is considered successful by Backpex and the action modal is closed. However, you can add an error flash message to the socket to indicate that something has gone wrong.
@@ -97,7 +100,7 @@ defmodule Backpex.ItemAction do
   @callback handle(socket :: Phoenix.LiveView.Socket.t(), items :: list(map()), params :: map() | struct()) ::
               {:ok, Phoenix.LiveView.Socket.t()} | {:error, Ecto.Changeset.t()}
 
-  @optional_callbacks confirm: 1, confirm_label: 1, cancel_label: 1, changeset: 3, fields: 0, link: 2
+  @optional_callbacks confirm: 1, confirm_label: 1, cancel_label: 1, changeset: 3, fields: 0, link: 2, handle: 3
 
   @doc """
   Defines `Backpex.ItemAction` behaviour and provides default implementations.
@@ -111,7 +114,22 @@ defmodule Backpex.ItemAction do
     end
   end
 
-  defmacro __before_compile__(_env) do
+  defmacro __before_compile__(env) do
+    handle_function? = Module.defines?(env.module, {:handle, 3})
+    link_function? = Module.defines?(env.module, {:link, 2})
+
+    if not handle_function? and not link_function? do
+      raise CompileError,
+        file: env.file,
+        line: env.line,
+        description: """
+        ItemAction #{inspect(env.module)} must implement at least one of handle/3 or link/2.
+
+        Implement handle/3 for actions that perform server-side operations,
+        or link/2 for actions that navigate to a URL.
+        """
+    end
+
     quote do
       @after_compile Backpex.ItemAction
 

--- a/lib/backpex/item_actions/item_action.ex
+++ b/lib/backpex/item_actions/item_action.ex
@@ -176,8 +176,8 @@ defmodule Backpex.ItemAction do
   end
 
   defp validate_handle_or_link!(env) do
-    handle_function? = Module.defines?(env.module, {:handle, 3})
-    link_function? = Module.defines?(env.module, {:link, 2})
+    handle_function? = Module.defines?(env.module, {:handle, 3}, :def)
+    link_function? = Module.defines?(env.module, {:link, 2}, :def)
 
     cond do
       not handle_function? and not link_function? ->

--- a/lib/backpex/item_actions/show.ex
+++ b/lib/backpex/item_actions/show.ex
@@ -24,10 +24,4 @@ defmodule Backpex.ItemActions.Show do
   def link(assigns, item) do
     Router.get_path(assigns.socket, assigns.live_resource, assigns.params, :show, item)
   end
-
-  @impl Backpex.ItemAction
-  def handle(socket, [item | _items], _data) do
-    path = Router.get_path(socket, socket.assigns.live_resource, socket.assigns.params, :show, item)
-    {:ok, Phoenix.LiveView.push_navigate(socket, to: path)}
-  end
 end

--- a/lib/backpex/item_actions/show.ex
+++ b/lib/backpex/item_actions/show.ex
@@ -21,6 +21,11 @@ defmodule Backpex.ItemActions.Show do
   def label(assigns, _item), do: Backpex.__("Show", assigns.live_resource)
 
   @impl Backpex.ItemAction
+  def link(assigns, item) do
+    Router.get_path(assigns.socket, assigns.live_resource, assigns.params, :show, item)
+  end
+
+  @impl Backpex.ItemAction
   def handle(socket, [item | _items], _data) do
     path = Router.get_path(socket, socket.assigns.live_resource, socket.assigns.params, :show, item)
     {:ok, Phoenix.LiveView.push_navigate(socket, to: path)}

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -412,32 +412,34 @@ defmodule Backpex.LiveResource do
             {@page_title}
           </.main_title>
           <div class="flex items-center space-x-2">
-            <.link
-              :for={{key, action} <- Backpex.HTML.Resource.filter_item_actions(@item_actions, :show)}
-              :if={Backpex.ItemAction.has_link?(action) and @live_resource.can?(assigns, key, @item)}
-              id={"item-action-#{key}"}
-              navigate={action.module.link(assigns, @item)}
-              aria-label={action.module.label(assigns, @item)}
-              phx-hook="BackpexTooltip"
-              data-tooltip={action.module.label(assigns, @item)}
-              class="cursor-pointer leading-none"
-            >
-              {action.module.icon(assigns, @item)}
-            </.link>
-            <button
-              :for={{key, action} <- Backpex.HTML.Resource.filter_item_actions(@item_actions, :show)}
-              :if={not Backpex.ItemAction.has_link?(action) and @live_resource.can?(assigns, key, @item)}
-              id={"item-action-#{key}"}
-              type="button"
-              phx-click="item-action"
-              phx-value-action-key={key}
-              aria-label={action.module.label(assigns, @item)}
-              phx-hook="BackpexTooltip"
-              data-tooltip={action.module.label(assigns, @item)}
-              class="cursor-pointer leading-none"
-            >
-              {action.module.icon(assigns, @item)}
-            </button>
+            <%= for {key, action} <- Backpex.HTML.Resource.filter_item_actions(@item_actions, :show),
+                    @live_resource.can?(assigns, key, @item) do %>
+              <%= if Backpex.ItemAction.has_link?(action) do %>
+                <.link
+                  id={"item-action-#{key}"}
+                  navigate={action.module.link(assigns, @item)}
+                  aria-label={action.module.label(assigns, @item)}
+                  phx-hook="BackpexTooltip"
+                  data-tooltip={action.module.label(assigns, @item)}
+                  class="cursor-pointer leading-none"
+                >
+                  {action.module.icon(assigns, @item)}
+                </.link>
+              <% else %>
+                <button
+                  id={"item-action-#{key}"}
+                  type="button"
+                  phx-click="item-action"
+                  phx-value-action-key={key}
+                  aria-label={action.module.label(assigns, @item)}
+                  phx-hook="BackpexTooltip"
+                  data-tooltip={action.module.label(assigns, @item)}
+                  class="cursor-pointer leading-none"
+                >
+                  {action.module.icon(assigns, @item)}
+                </button>
+              <% end %>
+            <% end %>
           </div>
         </div>
         """

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -412,9 +412,21 @@ defmodule Backpex.LiveResource do
             {@page_title}
           </.main_title>
           <div class="flex items-center space-x-2">
+            <.link
+              :for={{key, action} <- Backpex.HTML.Resource.filter_item_actions(@item_actions, :show)}
+              :if={Backpex.ItemAction.has_link?(action) and @live_resource.can?(assigns, key, @item)}
+              id={"item-action-#{key}"}
+              navigate={action.module.link(assigns, @item)}
+              aria-label={action.module.label(assigns, @item)}
+              phx-hook="BackpexTooltip"
+              data-tooltip={action.module.label(assigns, @item)}
+              class="cursor-pointer leading-none"
+            >
+              {action.module.icon(assigns, @item)}
+            </.link>
             <button
               :for={{key, action} <- Backpex.HTML.Resource.filter_item_actions(@item_actions, :show)}
-              :if={@live_resource.can?(assigns, key, @item)}
+              :if={not Backpex.ItemAction.has_link?(action) and @live_resource.can?(assigns, key, @item)}
               id={"item-action-#{key}"}
               type="button"
               phx-click="item-action"


### PR DESCRIPTION
closes #1854 

Item actions can now optionally implement a link/2 callback that returns a URL path. When present, the action renders as a <.link navigate={path}> instead of a <button>, enabling Ctrl+click to open in new tab and right-click context menus. Built-in Show and Edit actions implement link/2 by default. Fully backwards-compatible — existing actions without link/2 continue to render as buttons.