### PR TITLE
Add optional view link to InlineCRUD field rows

### DIFF
--- a/demo/lib/demo_web/live/product_live.ex
+++ b/demo/lib/demo_web/live/product_live.ex
@@ -124,6 +124,7 @@ defmodule DemoWeb.ProductLive do
         label: "Short Links",
         type: :assoc,
         except: [:index],
+        live_resource: DemoWeb.ShortLinkLive,
         child_fields: [
           short_key: %{
             module: Backpex.Fields.Text,

--- a/lib/backpex/fields/inline_crud.ex
+++ b/lib/backpex/fields/inline_crud.ex
@@ -19,6 +19,11 @@ defmodule Backpex.Fields.InlineCRUD do
       """,
       type: :keyword_list,
       required: true
+    ],
+    live_resource: [
+      doc:
+        "The live resource of the association. When provided, a link to each item's show page is rendered in the read-only view.",
+      type: :atom
     ]
   ]
 
@@ -86,6 +91,8 @@ defmodule Backpex.Fields.InlineCRUD do
   """
   use Backpex.Field, config_schema: @config_schema
 
+  alias Backpex.Router
+
   require Backpex
 
   @impl Phoenix.LiveComponent
@@ -128,6 +135,9 @@ defmodule Backpex.Fields.InlineCRUD do
             <th :for={{_name, %{label: label}} <- @child_fields} class="font-medium">
               {label}
             </th>
+            <th :if={@field_options[:live_resource]} class="font-medium">
+              <span class="sr-only">{Backpex.__("Actions", @live_resource)}</span>
+            </th>
           </tr>
         </thead>
         <tbody class="text-base-content/75">
@@ -142,6 +152,20 @@ defmodule Backpex.Fields.InlineCRUD do
                 )
               )}
             </td>
+            <%= if link = get_link(assigns, row) do %>
+              <td>
+                <div class="tooltip" data-tip={Backpex.__("Show", @live_resource)}>
+                  <.link navigate={link} aria-label={Backpex.__("Show", @live_resource)}>
+                    <Backpex.HTML.CoreComponents.icon
+                      name="hero-eye"
+                      class="h-5 w-5 cursor-pointer transition duration-75 hover:text-success hover:scale-110"
+                    />
+                  </.link>
+                </div>
+              </td>
+            <% else %>
+              <td :if={@field_options[:live_resource]} />
+            <% end %>
           </tr>
         </tbody>
       </table>
@@ -231,6 +255,14 @@ defmodule Backpex.Fields.InlineCRUD do
   def schema({name, _field_options}, schema) do
     schema.__schema__(:association, name)
     |> Map.get(:queryable)
+  end
+
+  defp get_link(assigns, row) do
+    live_resource = Map.get(assigns.field_options, :live_resource)
+
+    if live_resource && live_resource.can?(assigns, :show, row) do
+      Router.get_path(assigns.socket, live_resource, assigns.params, :show, row)
+    end
   end
 
   defp child_field_class(%{class: class} = _child_field_options, assigns) when is_function(class), do: class.(assigns)


### PR DESCRIPTION
closes #1857 

When a live_resource option is provided on an InlineCRUD field, each row in the read-only table view gets an eye icon link that navigates to the associated resource's show page. This mirrors the existing pattern used by BelongsTo and HasMany fields.

The link includes a tooltip and respects authorization via can?/3. When live_resource is not set, no action column is rendered, keeping the feature fully backwards-compatible.

<img width="752" height="198" alt="image" src="https://github.com/user-attachments/assets/f9403795-0d99-4a3a-9006-9bd8332c3a5f" />