### PR TITLE
Fix release reset task failing with insufficient privileges

### DIFF
--- a/demo/lib/demo/release.ex
+++ b/demo/lib/demo/release.ex
@@ -12,7 +12,7 @@ defmodule Demo.Release do
 
   defp drop_tables(repo) do
     %{rows: rows} =
-      repo.query!("SELECT quote_ident(tablename) FROM pg_tables WHERE schemaname = 'public'")
+      repo.query!("SELECT format('%I.%I', schemaname, tablename) FROM pg_tables WHERE schemaname = 'public'")
 
     tables = List.flatten(rows)
 

--- a/demo/lib/demo/release.ex
+++ b/demo/lib/demo/release.ex
@@ -36,7 +36,7 @@ defmodule Demo.Release do
   end
 
   @doc """
-  Reset the application by dropping and recreating the public schema.
+  Reset the application by dropping all owned database objects, then re-migrating and seeding.
   """
   def reset do
     init([:ssl])
@@ -44,8 +44,15 @@ defmodule Demo.Release do
     for repo <- repos() do
       {:ok, _fun_return, _apps} =
         Ecto.Migrator.with_repo(repo, fn repo ->
-          repo.query!("DROP SCHEMA public CASCADE")
-          repo.query!("CREATE SCHEMA public")
+          %{rows: rows} =
+            repo.query!("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
+
+          tables = List.flatten(rows)
+
+          if tables != [] do
+            joined = Enum.map_join(tables, ", ", &~s("#{&1}"))
+            repo.query!("DROP TABLE #{joined} CASCADE")
+          end
         end)
     end
 

--- a/demo/lib/demo/release.ex
+++ b/demo/lib/demo/release.ex
@@ -10,6 +10,18 @@ defmodule Demo.Release do
 
   defp repos, do: Application.fetch_env!(@app, :ecto_repos)
 
+  defp drop_tables(repo) do
+    %{rows: rows} =
+      repo.query!("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
+
+    tables = List.flatten(rows)
+
+    if tables != [] do
+      joined = Enum.map_join(tables, ", ", &~s("#{&1}"))
+      repo.query!("DROP TABLE #{joined} CASCADE")
+    end
+  end
+
   @doc """
   Migrate the database.
   """
@@ -36,24 +48,14 @@ defmodule Demo.Release do
   end
 
   @doc """
-  Reset the application by dropping all owned database objects, then re-migrating and seeding.
+  Reset the application by dropping all tables in the public schema, then re-migrating and seeding.
   """
   def reset do
     init([:ssl])
 
     for repo <- repos() do
       {:ok, _fun_return, _apps} =
-        Ecto.Migrator.with_repo(repo, fn repo ->
-          %{rows: rows} =
-            repo.query!("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
-
-          tables = List.flatten(rows)
-
-          if tables != [] do
-            joined = Enum.map_join(tables, ", ", &~s("#{&1}"))
-            repo.query!("DROP TABLE #{joined} CASCADE")
-          end
-        end)
+        Ecto.Migrator.with_repo(repo, &drop_tables/1)
     end
 
     migrate()

--- a/demo/lib/demo/release.ex
+++ b/demo/lib/demo/release.ex
@@ -12,12 +12,12 @@ defmodule Demo.Release do
 
   defp drop_tables(repo) do
     %{rows: rows} =
-      repo.query!("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
+      repo.query!("SELECT quote_ident(tablename) FROM pg_tables WHERE schemaname = 'public'")
 
     tables = List.flatten(rows)
 
     if tables != [] do
-      joined = Enum.map_join(tables, ", ", &~s("#{&1}"))
+      joined = Enum.join(tables, ", ")
       repo.query!("DROP TABLE #{joined} CASCADE")
     end
   end


### PR DESCRIPTION
- `Demo.Release.reset/0` failed with `insufficient_privilege` error because `DROP SCHEMA public CASCADE` requires ownership of the public schema