### PR TITLE
Fix: make on_item_created/updated/deleted overridable without compiler warnings

### DIFF
--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -320,6 +320,15 @@ defmodule Backpex.LiveResource do
       @impl Backpex.LiveResource
       def item_actions(default_actions), do: default_actions
 
+      @impl Backpex.LiveResource
+      def on_item_created(socket, _item), do: socket
+
+      @impl Backpex.LiveResource
+      def on_item_updated(socket, _item), do: socket
+
+      @impl Backpex.LiveResource
+      def on_item_deleted(socket, _item), do: socket
+
       defoverridable can?: 3,
                      fields: 0,
                      filters: 0,
@@ -327,7 +336,10 @@ defmodule Backpex.LiveResource do
                      layout: 1,
                      resource_actions: 0,
                      item_actions: 1,
-                     index_row_class: 4
+                     index_row_class: 4,
+                     on_item_created: 2,
+                     on_item_updated: 2,
+                     on_item_deleted: 2
 
       live_resource = __MODULE__
 
@@ -376,15 +388,6 @@ defmodule Backpex.LiveResource do
 
       @impl Backpex.LiveResource
       def metrics, do: []
-
-      @impl Backpex.LiveResource
-      def on_item_created(socket, _item), do: socket
-
-      @impl Backpex.LiveResource
-      def on_item_updated(socket, _item), do: socket
-
-      @impl Backpex.LiveResource
-      def on_item_deleted(socket, _item), do: socket
 
       @impl Backpex.LiveResource
       def return_to(socket, assigns, _live_action, _form_action, _item) do


### PR DESCRIPTION
## Summary

Moves `on_item_created/2`, `on_item_updated/2`, and `on_item_deleted/2` default implementations from `__before_compile__` into `__using__` and adds them to the `defoverridable` list.

## Problem

When overriding these callbacks in a LiveResource module, the Elixir compiler emits a "redundant clause" warning:

```
warning: the following clause is redundant:

    def on_item_updated(socket, _item)

it has type:

    dynamic(), dynamic()

previous clauses have already matched on the following types:

    term(), term()
```

This happens because the defaults are defined in `__before_compile__`, which runs **after** the module body. The user's override becomes an earlier clause matching `(term(), term())`, making Backpex's default clause unreachable — correct behavior, but with a noisy warning.

## Fix

Move the three `on_item_*` defaults into the `__using__` block (alongside the other defaults like `can?/3`, `fields/0`, etc.) and add them to the existing `defoverridable` call. This lets users override them cleanly without compiler warnings.

## Test plan

- Verified in a consuming Phoenix app that overriding `on_item_updated/2` no longer produces the warning
- Full test suite passes with no regressions