### PR TITLE
Add Claude Code launch.json with dev server configs

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,18 +6,6 @@
       "runtimeExecutable": "docker",
       "runtimeArgs": ["compose", "up", "app"],
       "port": 4000
-    },
-    {
-      "name": "LiveDebugger",
-      "runtimeExecutable": "docker",
-      "runtimeArgs": ["compose", "up", "app"],
-      "port": 4007
-    },
-    {
-      "name": "PostgreSQL",
-      "runtimeExecutable": "docker",
-      "runtimeArgs": ["compose", "up", "postgres"],
-      "port": 54321
     }
   ]
 }

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "Demo App (Phoenix LiveView)",
       "runtimeExecutable": "docker",
-      "runtimeArgs": ["compose", "up", "app"],
+      "runtimeArgs": ["compose", "up"],
       "port": 4000
     }
   ]

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Demo App (Phoenix LiveView)",
+      "runtimeExecutable": "docker",
+      "runtimeArgs": ["compose", "up", "app"],
+      "port": 4000
+    },
+    {
+      "name": "LiveDebugger",
+      "runtimeExecutable": "docker",
+      "runtimeArgs": ["compose", "up", "app"],
+      "port": 4007
+    },
+    {
+      "name": "PostgreSQL",
+      "runtimeExecutable": "docker",
+      "runtimeArgs": ["compose", "up", "postgres"],
+      "port": 54321
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/launch.json` with a single dev server configuration for the Phoenix LiveView demo app on port 4000, starting it via `docker compose up`.
- Lets Claude Code's preview tooling start the project's dev server by name.

## Test plan
- [x] Verify `.claude/launch.json` parses as valid JSON
- [x] Confirm Claude Code's preview tooling recognizes the configuration and brings up the demo app on port 4000