### PR TITLE
Preserve filters_changed flag in confirmed item action return URL

### DIFF
--- a/demo/test/demo_web/live/post/filter_live_test.exs
+++ b/demo/test/demo_web/live/post/filter_live_test.exs
@@ -356,6 +356,57 @@ defmodule DemoWeb.Live.Post.FilterLiveTest do
     end
   end
 
+  describe "filters_changed preservation across confirmed item actions" do
+    test "delete item action preserves cleared default filter", %{conn: conn} do
+      # Insert without tags to avoid the posts_tags FK preventing the delete.
+      insert(:post, title: "Published Post", published: true, tags: [])
+      draft_to_keep = insert(:post, title: "Draft to Keep", published: false, tags: [])
+      draft_to_delete = insert(:post, title: "Draft to Delete", published: false, tags: [])
+
+      session =
+        conn
+        |> visit(~p"/admin/posts")
+        |> assert_has("table tbody tr", count: 1)
+        |> assert_has("td", text: "Published Post")
+        |> refute_has("td", text: "Draft to Keep")
+        |> unwrap(fn view ->
+          view
+          |> element("button[phx-click='clear-filter'][phx-value-field='published'][aria-label]")
+          |> render_click()
+        end)
+        |> assert_has("table tbody tr", count: 3)
+        |> assert_has("td", text: "Draft to Keep")
+        |> unwrap(fn view ->
+          view
+          |> element("button[aria-label='Delete'][phx-value-item-id='#{draft_to_delete.id}']")
+          |> render_click()
+        end)
+        |> unwrap(fn view ->
+          view
+          |> form("#resource-form")
+          |> render_submit()
+        end)
+
+      # After the confirmed delete the form component runs `push_navigate(return_to)`,
+      # which remounts the index. Without the fix the URL would lose `filters_changed`,
+      # so `maybe_redirect_to_default_filters/1` would re-apply `filters[published]=published`
+      # and the remaining draft post would disappear from the table.
+      session
+      |> assert_path(~p"/admin/posts",
+        query_params: %{
+          "filters_changed" => "true",
+          "order_by" => "id",
+          "order_direction" => "asc",
+          "per_page" => "15",
+          "page" => "1"
+        }
+      )
+      |> assert_has("td", text: "Published Post")
+      |> assert_has("td", text: draft_to_keep.title)
+      |> refute_has("td", text: draft_to_delete.title)
+    end
+  end
+
   describe "filter badges" do
     test "shows badge for active category filter", %{conn: conn} do
       category = insert(:category, name: "Technology")

--- a/lib/backpex/live_resource/index.ex
+++ b/lib/backpex/live_resource/index.ex
@@ -468,10 +468,13 @@ defmodule Backpex.LiveResource.Index do
   end
 
   defp apply_index_return_to(socket) do
-    %{live_resource: live_resource, params: params, query_options: query_options} = socket.assigns
+    %{live_resource: live_resource, params: params, query_options: query_options, filters_changed: filters_changed} =
+      socket.assigns
 
-    socket
-    |> assign(:return_to, Router.get_path(socket, live_resource, params, :index, query_options))
+    return_to_options =
+      if filters_changed, do: Map.put(query_options, :filters_changed, "true"), else: query_options
+
+    assign(socket, :return_to, Router.get_path(socket, live_resource, params, :index, return_to_options))
   end
 
   # TODO: move to common module


### PR DESCRIPTION
## Summary

Fixes a bug where confirmed item actions (built-in `Backpex.ItemActions.Delete` or any custom `ItemAction` with a `confirm/1` callback) silently re-apply default filters on a `LiveResource` whose `filters/1` declares a filter with a `default:` value, even when the user has explicitly cleared them.

Reproduced on Backpex 0.18.0 / `develop`.

## Root cause

Three pieces interacted to lose the user's cleared-filter state:

1. `apply_index_return_to/1` in `lib/backpex/live_resource/index.ex` built `socket.assigns.return_to` from `query_options`, which carries `:filters`, `:page`, `:per_page`, `:order_by`, `:order_direction`, `:search` — but **not** the transient `filters_changed` flag (which lives only in `socket.assigns.filters_changed` and as a URL query param).
2. `Backpex.FormComponent.handle_form_item_action/3` calls `push_navigate(to: return_to)` after a successful confirmed action, so the URL it lands on is missing `filters_changed=true`.
3. On the next mount, `assign_filters_changed_status/2` reads `params["filters_changed"]` (now missing) → `filters_changed: false`. `maybe_redirect_to_default_filters/1` then sees `filters_changed == false` AND `query_options.filters == %{}` AND filters with `default:` exist → push-navigates to a URL with defaults applied. The user's cleared state is silently overwritten.

## Fix

Carry `filters_changed=true` through the `return_to` URL whenever the flag is currently set on the socket. This is the smallest correct change: it keeps `maybe_redirect_to_default_filters/1` intact for fresh navigation while preserving user state across `push_navigate` round-trips through the form component.

The router-level `Backpex.Router.get_path/5` is intentionally **not** changed, because `maybe_redirect_to_default_filters/1` itself calls it — that path must NOT gain `filters_changed=true`, since it represents the system applying defaults, not the user.

## Regression test

Added `describe "filters_changed preservation across confirmed item actions"` in `demo/test/demo_web/live/post/filter_live_test.exs`. The demo's `PostLive` already had the perfect fixture — a `published` filter with `default: ["published"]` plus the built-in delete item action. The test:

1. Inserts one published and two unpublished posts.
2. Visits `/admin/posts` and confirms only the published post is visible (default filter applied).
3. Clears the `published` filter via the existing clear-filter UI control.
4. Triggers the delete confirm modal on one of the unpublished rows and submits it.
5. Asserts the URL still contains `filters_changed=true` and that the surviving unpublished post is still visible (i.e. the default filter has not snapped back).

Verified the test catches the bug by temporarily reverting the fix — the assertion fails with the URL becoming `filters[published][]=published&...`.

## Verification

- `mix lint` (Backpex library): passes — 95 doctests, 164 tests, 0 failures.
- `mix test test/demo_web/live/post/filter_live_test.exs` (demo): passes — 24 tests, 0 failures.
- End-to-end browser verification through the running demo at `/admin/posts`: cleared the default `published` filter, opened the delete modal on an unpublished post, confirmed. After navigation the URL is `?order_by=id&order_direction=asc&per_page=15&page=1&filters_changed=true` (flag preserved, defaults not re-applied) and unpublished posts remain visible.

## Test plan

- [x] `mix lint` on Backpex library
- [x] `mix test test/demo_web/live/post/filter_live_test.exs` in the demo
- [x] End-to-end smoke test through the demo at `/admin/posts`
- [x] Confirmed regression test fails without the fix