### PR TITLE
Fix ArgumentError when a host LiveView uses stream/3 by dropping reserved assigns at every field-component spread site

### DIFF
--- a/lib/backpex/html/item_action.ex
+++ b/lib/backpex/html/item_action.ex
@@ -36,7 +36,7 @@ defmodule Backpex.HTML.ItemAction do
           id={:item_action_modal}
           live_resource={@live_resource}
           action_type={:item}
-          {Map.drop(assigns, [:socket, :flash, :fields])}
+          {Map.drop(assigns, [:fields | Backpex.HTML.Resource.lv_reserved_assigns()])}
         />
       </div>
     </Layout.modal>

--- a/lib/backpex/html/resource.ex
+++ b/lib/backpex/html/resource.ex
@@ -18,6 +18,16 @@ defmodule Backpex.HTML.Resource do
   embed_templates("resource/*")
 
   @doc """
+  Returns the list of assigns that `Phoenix.LiveView` reserves and that must be dropped
+  before spreading parent assigns into a child `Phoenix.LiveComponent`.
+
+  `Phoenix.Component.assign/3` rejects these keys with an `ArgumentError`. Centralizing
+  the list here ensures every spread site forwards the same safe subset of the parent's
+  assigns.
+  """
+  def lv_reserved_assigns, do: [:flash, :uploads, :streams, :socket, :myself]
+
+  @doc """
   Renders a resource table.
   """
   @doc type: :component
@@ -112,7 +122,7 @@ defmodule Backpex.HTML.Resource do
       id={"resource_#{@name}_#{@primary_key}"}
       module={@field_options.module}
       type={@type}
-      {Map.drop(assigns, [:socket, :flash, :myself, :uploads])}
+      {Map.drop(assigns, lv_reserved_assigns())}
     />
     """
   end
@@ -148,7 +158,7 @@ defmodule Backpex.HTML.Resource do
       id={@id}
       module={@field_options.module}
       type={@type}
-      {Map.drop(assigns, [:socket, :flash, :myself, :uploads])}
+      {Map.drop(assigns, lv_reserved_assigns())}
     />
     """
   end
@@ -183,7 +193,7 @@ defmodule Backpex.HTML.Resource do
       module={@field_options.module}
       lv_uploads={assigns[:uploads]}
       type={@type}
-      {Map.drop(assigns, [:socket, :flash, :myself, :uploads])}
+      {Map.drop(assigns, lv_reserved_assigns())}
     />
     """
   end

--- a/lib/backpex/html/resource/resource_form_main.html.heex
+++ b/lib/backpex/html/resource/resource_form_main.html.heex
@@ -3,6 +3,6 @@
     module={Backpex.FormComponent}
     id={:edit}
     live_resource={@live_resource}
-    {Map.drop(assigns, [:socket, :flash])}
+    {Map.drop(assigns, lv_reserved_assigns())}
   />
 </.main_container>

--- a/lib/backpex/html/resource/resource_index.html.heex
+++ b/lib/backpex/html/resource/resource_index.html.heex
@@ -12,7 +12,7 @@
       id={:modal}
       live_resource={@live_resource}
       action_type={:resource}
-      {Map.drop(assigns, [:socket, :flash, :fields])}
+      {Map.drop(assigns, [:fields | lv_reserved_assigns()])}
     />
   </.modal>
 

--- a/test/backpex/html/resource_test.exs
+++ b/test/backpex/html/resource_test.exs
@@ -1,0 +1,24 @@
+defmodule Backpex.HTML.ResourceTest do
+  use ExUnit.Case, async: true
+
+  alias Backpex.HTML.Resource
+
+  describe "lv_reserved_assigns/0" do
+    test "includes every assign reserved by Phoenix.LiveView" do
+      reserved = Resource.lv_reserved_assigns()
+
+      for key <- [:flash, :uploads, :streams, :socket, :myself] do
+        assert key in reserved, "expected #{inspect(key)} in lv_reserved_assigns/0"
+      end
+    end
+
+    test "dropping the reserved set removes :streams from a parent-style assigns map" do
+      assigns = %{streams: %{example: :ref}, foo: 1, bar: 2}
+
+      result = Map.drop(assigns, Resource.lv_reserved_assigns())
+
+      refute Map.has_key?(result, :streams)
+      assert result == %{foo: 1, bar: 2}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Backpex spreads the parent LiveView's `assigns` into child field LiveComponents after dropping a hand-maintained list of keys. That list was missing `:streams` everywhere, and `:uploads` / `:myself` at three of the six sites. When a host LiveView calls `stream(socket, :name, [])` (or `allow_upload/3`), the reserved key flows into the child and `Phoenix.Component.assign/3` raises:

```
** (ArgumentError) :streams is a reserved assign by LiveView and it cannot be set directly
    (phoenix_live_view 1.1.30) lib/phoenix_component.ex:1467: Phoenix.Component.validate_assign_key!/1
    (phoenix_live_view 1.1.30) lib/phoenix_component.ex:1405: Phoenix.Component.assign/3
    (stdlib 7.3) maps.erl:894: :maps.fold_1/4
    (backpex 0.18.x) lib/backpex/fields/belongs_to.ex:77: Backpex.Fields.BelongsTo.update/2
```

This affects every field whose `update/2` does `socket |> assign(assigns)`: `BelongsTo`, `HasMany`, `HasManyThrough`, `MultiSelect`, `InlineCRUD`.

## Changes

- Add `Backpex.HTML.Resource.lv_reserved_assigns/0` returning `[:flash, :uploads, :streams, :socket, :myself]` — the full set rejected by `Phoenix.Component.assign/3` (plus `:flash`, which was already dropped at every site).
- Route all six `Map.drop(assigns, ...)` spread sites through the new helper:
  - `lib/backpex/html/resource.ex` (3 sites: `live_resource_field/1`, `inlined_resource_field/1`, `resource_form_field/1`)
  - `lib/backpex/html/item_action.ex` (1 site)
  - `lib/backpex/html/resource/resource_form_main.html.heex` (1 site)
  - `lib/backpex/html/resource/resource_index.html.heex` (1 site)
  Site-specific extras (`:fields`) are prepended with `[:fields | lv_reserved_assigns()]`.
- Add `test/backpex/html/resource_test.exs` asserting the helper returns the full reserved set and that dropping it removes `:streams` from a parent-style assigns map.

No version bump in this PR — will be handled separately when the release is cut.

## Test plan

- [x] `mix format`
- [x] `mix lint` (compile / credo / 95 doctests + 166 tests, 0 failures)
- [x] `mix test test/backpex/html/resource_test.exs` — 2/2 pass
- [x] Demo smoke test in browser: Posts index, Posts /new, Users index, Send-email resource action modal — all render without server or console errors
- [x] Verify in a consumer app that calls `stream/3` on mount and renders a `BelongsTo` field — page renders without `ArgumentError`