### PR TITLE
Fix undefined type attribute warning on currency_input

### DIFF
--- a/lib/backpex/fields/currency.ex
+++ b/lib/backpex/fields/currency.ex
@@ -97,7 +97,6 @@ defmodule Backpex.Fields.Currency do
           <Layout.input_label for={@form[@name]} text={@field_options[:label]} />
         </:label>
         <BackpexForm.currency_input
-          type="text"
           field={@form[@name]}
           translate_error_fun={Backpex.Field.translate_error_fun(@field_options, assigns)}
           help_text={Backpex.Field.help_text(@field_options, assigns)}


### PR DESCRIPTION
## What

Removes the invalid `type="text"` attribute passed to the `Backpex.HTML.Form.currency_input/1` component in the currency field's `render_form/1`.

## Why

The `currency_input/1` component does not define a `type` attribute, so passing `type="text"` triggered:

```
warning: undefined attribute "type" for component Backpex.HTML.Form.currency_input/1
lib/backpex/fields/currency.ex:100
```

This broke `mix compile --warnings-as-errors`. The rendered input already defaults to `text`, so removing the attribute has no functional impact.