### PR TITLE
ci: cache bun store instead of node_modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,17 +72,15 @@ jobs:
       - name: Compile with warnings as errors
         run: mix compile --warnings-as-errors --force
 
-      - name: Cache node modules
+      - name: Cache bun install cache
         uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-        id: bun-cache
         with:
-          path: node_modules
-          key: ${{ runner.os }}-node-24-bun-${{ hashFiles('bun.lock') }}
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-store-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-24-bun-
+            ${{ runner.os }}-bun-store-
 
       - name: Install node dependencies
-        if: steps.bun-cache.outputs.cache-hit != 'true'
         run: bun install --frozen-lockfile
 
       - name: Check formatting
@@ -212,31 +210,19 @@ jobs:
         working-directory: demo
         run: mix compile --warnings-as-errors --force
 
-      - name: Cache node modules
+      - name: Cache bun install cache
         uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-        id: bun-cache
         with:
-          path: demo/node_modules
-          key: ${{ runner.os }}-node-24-bun-demo-${{ hashFiles('demo/bun.lock') }}
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-store-${{ hashFiles('demo/bun.lock', 'bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-24-bun-demo-
+            ${{ runner.os }}-bun-store-
 
       - name: Install node dependencies
-        if: steps.bun-cache.outputs.cache-hit != 'true'
         working-directory: demo
         run: bun install --frozen-lockfile
 
-      - name: Cache Backpex node modules
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-        id: bun-cache-backpex
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-24-bun-backpex-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-24-bun-backpex-
-
       - name: Install Backpex node dependencies
-        if: steps.bun-cache-backpex.outputs.cache-hit != 'true'
         run: bun install --frozen-lockfile
 
       - name: Setup assets

--- a/.github/workflows/elixir-main.yml
+++ b/.github/workflows/elixir-main.yml
@@ -48,17 +48,15 @@ jobs:
       - name: Compile with warnings as errors
         run: mix compile --warnings-as-errors --force
 
-      - name: Cache node modules
+      - name: Cache bun install cache
         uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-        id: bun-cache
         with:
-          path: node_modules
-          key: ${{ runner.os }}-node-24-bun-${{ hashFiles('bun.lock') }}
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-store-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-24-bun-
+            ${{ runner.os }}-bun-store-
 
       - name: Install node dependencies
-        if: steps.bun-cache.outputs.cache-hit != 'true'
         run: bun install --frozen-lockfile
 
       - name: Check formatting


### PR DESCRIPTION
## Problem

CI's `Test (Demo)` → `lint:style` step crashes on dependency/lockfile PRs (first observed on #1974):

```
stylelint assets/**/*.css
node_modules/@cacheable/memory/dist/index.js:115
import { Keyv } from "keyv";
SyntaxError: The requested module 'keyv' does not provide an export named 'Keyv'
```

### Root cause

The workflows cached `node_modules` directly with a `restore-keys:` fallback and only ran `bun install --frozen-lockfile` on a cache miss. When a lockfile changed:

1. The exact cache key missed, so `restore-keys` restored a **stale `node_modules`** built from a *different* lockfile (e.g. develop's `@cacheable/memory@2.0.8`).
2. A partial restore leaves `cache-hit != 'true'`, so `bun install --frozen-lockfile` ran **incrementally on top of the stale tree**.
3. That incremental install could leave a broken hoist: `@cacheable/memory` (ESM, `import { Keyv } from "keyv"`, needs `keyv@5`) resolving up to the top-level hoisted `keyv@4.5.4` (pulled in by eslint's `flat-cache@3.2.0`, no named `Keyv` export) instead of its nested `keyv@5.6.0` → stylelint crashes before linting anything.

A **clean** `bun install --frozen-lockfile` of the same lockfile produces the correct tree and passes — the failure only happens via the cached/incremental path. Caching `node_modules` with `restore-keys` is the anti-pattern here.

## Fix

Cache bun's content-addressed install store (`~/.bun/install/cache`) instead of `node_modules`, and **always** run `bun install --frozen-lockfile`:

- `node_modules` is rebuilt cleanly from the lockfile on every run → correct hoisting, no stale-tree carryover.
- Installs stay fast because packages come from the warm store (no re-download), not the network. `restore-keys` is safe on a package store (it's just tarballs, not a hoisted layout).
- The Demo job uses a single store cache keyed on both `demo/bun.lock` and `bun.lock`, feeding both the demo and Backpex installs.

Applied to both `ci.yml` (Backpex + Demo jobs) and `elixir-main.yml`.

## Notes

- The common case (lockfile unchanged) is essentially unaffected — installs hit the warm store and materialize `node_modules` via hardlinks in ~1s.
- Once this lands on `develop`, re-running #1974's CI (rebased) should go green.