### PR TITLE
Add Elixir 1.20 and OTP 29 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           - elixir: "1.19"
             otp: "28.1"
 
+          - elixir: "1.20"
+            otp: "29.0"
+
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Description

Adds an Elixir 1.20 / OTP 29 entry to the `test` job matrix in `.github/workflows/ci.yml`, extending CI coverage to the latest Elixir/OTP release pair.

## Changes

- Add `elixir: "1.20"` / `otp: "29.0"` to the backpex test matrix (alongside the existing 1.16–1.19 entries).

## Notes

Scoped to the main `test` matrix. The `test-demo` and `publish` jobs continue to derive their versions from `.tool-versions`, and `elixir-main.yml` remains unchanged.