### PR TITLE
Add selectedcontent button to select inputs

### DIFF
--- a/lib/backpex/filters/select.ex
+++ b/lib/backpex/filters/select.ex
@@ -111,6 +111,9 @@ defmodule Backpex.Filters.Select do
       ]}
       aria-label={@prompt}
     >
+      <button>
+        <selectedcontent></selectedcontent>
+      </button>
       <option value="">{@prompt}</option>
       {Phoenix.HTML.Form.options_for_select(@options, selected(@value))}
     </select>

--- a/lib/backpex/html/form.ex
+++ b/lib/backpex/html/form.ex
@@ -117,6 +117,9 @@ defmodule Backpex.HTML.Form do
           multiple={@multiple}
           {@rest}
         >
+          <button>
+            <selectedcontent></selectedcontent>
+          </button>
           <option :if={@prompt} value="">{@prompt}</option>
           {Phoenix.HTML.Form.options_for_select(@options, @value)}
         </select>

--- a/lib/backpex/html/resource.ex
+++ b/lib/backpex/html/resource.ex
@@ -869,6 +869,9 @@ defmodule Backpex.HTML.Resource do
     ~H"""
     <.form for={@form} class={@class} phx-change="select-page-size" phx-submit="select-page-size">
       <select name={@form[:value].name} class="select select-sm" aria-label={Backpex.__("Items per page", @live_resource)}>
+        <button>
+          <selectedcontent></selectedcontent>
+        </button>
         {Phoenix.HTML.Form.options_for_select(@options, @selected)}
       </select>
     </.form>


### PR DESCRIPTION
## What

Adds a customizable-select trigger to every native `<select>` in Backpex:

```html
<button>
  <selectedcontent></selectedcontent>
</button>
```

inserted as the **first child** of each `<select>`. Affected selects:

- `Backpex.HTML.Form.input/1` (`type="select"`) — the shared select input used by the `select` and `belongs_to` fields
- `Backpex.Filters.Select.render_form/1` — the select filter
- `Backpex.HTML.Resource.select_per_page/1` — the "items per page" picker

## Why

Backpex already ships `::picker(select)` utility classes (e.g. in the error styling of the select input), which only take effect under `appearance: base-select`. This change completes that direction: with the customizable-select rendering, `<selectedcontent>` mirrors the currently selected `<option>`'s content into the styleable trigger `<button>`, while the element stays a real native `<select>` — keyboard support, form submission and accessibility semantics are unchanged.

Browsers without customizable-select support simply ignore the `<button>` and fall back to the standard native `<select>`, so this is a progressive enhancement.

## Notes for review

- The form select supports `multiple={@multiple}`. The `<button>`/`<selectedcontent>` pattern is meaningful for single-select comboboxes only; for `multiple` selects it is inert. I added it unconditionally per the change's intent — happy to guard it with `:if={!@multiple}` if preferred.

## Verification (local)

- `mix compile --warnings-as-errors --force` ✅ (HEEx accepts `<button>` inside `<select>`)
- `mix format --check-formatted` ✅
- `mix test` ✅ 166 tests, 95 doctests, 0 failures
- `mix credo` ✅ no issues
- `mix docs --warnings-as-errors` ✅