### PR TITLE
Support `return_to` URL param in the show view

### DIFF
--- a/demo/test/demo_web/live/user/soft_delete_item_action_live_test.exs
+++ b/demo/test/demo_web/live/user/soft_delete_item_action_live_test.exs
@@ -92,6 +92,60 @@ defmodule DemoWeb.Live.User.SoftDeleteItemActionLiveTest do
       |> refute_has("td", text: "showuser")
     end
 
+    test "show view item action honors a valid ?return_to param", %{conn: conn} do
+      user = insert(:user, %{username: "returnuser"})
+
+      conn
+      |> visit(~p"/admin/users/#{user.id}/show?return_to=/admin/products")
+      |> unwrap(fn view ->
+        view
+        |> element("#item-action-user_soft_delete")
+        |> render_click()
+      end)
+      |> unwrap(fn view ->
+        view
+        |> form("#resource-form", change: %{reason: "Returning to products"})
+        |> render_submit()
+      end)
+      |> assert_path(~p"/admin/products")
+    end
+
+    test "show view item action ignores an external ?return_to param", %{conn: conn} do
+      user = insert(:user, %{username: "externaluser"})
+
+      conn
+      |> visit(~p"/admin/users/#{user.id}/show?return_to=https://evil.com")
+      |> unwrap(fn view ->
+        view
+        |> element("#item-action-user_soft_delete")
+        |> render_click()
+      end)
+      |> unwrap(fn view ->
+        view
+        |> form("#resource-form", change: %{reason: "Rejecting external redirect"})
+        |> render_submit()
+      end)
+      |> assert_path(~p"/admin/users")
+    end
+
+    test "show view item action ignores a protocol-relative ?return_to param", %{conn: conn} do
+      user = insert(:user, %{username: "protocoluser"})
+
+      conn
+      |> visit(~p"/admin/users/#{user.id}/show?return_to=//evil.com")
+      |> unwrap(fn view ->
+        view
+        |> element("#item-action-user_soft_delete")
+        |> render_click()
+      end)
+      |> unwrap(fn view ->
+        view
+        |> form("#resource-form", change: %{reason: "Rejecting protocol-relative redirect"})
+        |> render_submit()
+      end)
+      |> assert_path(~p"/admin/users")
+    end
+
     test "admin users cannot be soft deleted", %{conn: conn} do
       admin_user = insert(:user, %{username: "adminuser", role: :admin})
 

--- a/guides/live_resource/navigation.md
+++ b/guides/live_resource/navigation.md
@@ -35,3 +35,24 @@ When working with forms (in `:new` or  `:edit` live actions), the following form
 - `:cancel` - When a form submission is canceled aka the "Cancel" button was clicked
 
 For all other live actions, the form_action will be `nil`.
+
+## Overriding the destination per link (`return_to`)
+
+Sometimes the destination depends on where the user came from rather than on the
+resource itself. For these cases you can append a `return_to` query parameter to
+any `:new`, `:edit`, or `:show` URL. Backpex uses it as the navigation target
+after the form is saved/cancelled or after an item action completes, overriding
+the default index/show path.
+
+```elixir
+# link into the show view and send the user back to a custom page afterwards
+~p"/admin/posts/#{post}/show?return_to=/dashboard"
+```
+
+This is useful, for example, when a notification links to a resource and you want
+the user to return to the notification list once they have acted on it.
+
+Only same-origin, absolute paths are honored. Any value that carries a scheme or
+host (`https://example.com`, `//example.com`, `/\example.com`) is ignored to
+prevent open redirects, and Backpex falls back to the default destination. Paths
+may include query strings (e.g. `/admin/posts?page=2`).

--- a/guides/live_resource/navigation.md
+++ b/guides/live_resource/navigation.md
@@ -41,7 +41,7 @@ For all other live actions, the form_action will be `nil`.
 Sometimes the destination depends on where the user came from rather than on the
 resource itself. For these cases you can append a `return_to` query parameter to
 any `:new`, `:edit`, or `:show` URL. Backpex uses it as the navigation target
-after the form is saved/cancelled or after an item action completes, overriding
+after the form is saved/canceled or after an item action completes, overriding
 the default index/show path.
 
 ```elixir

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -985,6 +985,9 @@ defmodule Backpex.LiveResource do
       iex> Backpex.LiveResource.return_to_param(%{"return_to" => "//evil.com"})
       nil
 
+      iex> Backpex.LiveResource.return_to_param(%{"return_to" => "/\\evil.com"})
+      nil
+
       iex> Backpex.LiveResource.return_to_param(%{})
       nil
   """

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -960,4 +960,48 @@ defmodule Backpex.LiveResource do
 
     socket
   end
+
+  @doc """
+  Extracts a safe `return_to` path from the given params.
+
+  Backpex uses the `return_to` value to determine where to navigate after an
+  item has been created, updated, or acted on via an item action. By appending
+  a `?return_to=` query parameter to a resource URL you can override that
+  destination, e.g. to send the user back to the page they came from.
+
+  Only same-origin, absolute paths are accepted. Any value carrying a scheme or
+  host (`https://example.com`, `//example.com`, `/\\example.com`) is rejected to
+  prevent open redirects, in which case `nil` is returned and callers should
+  fall back to their default destination.
+
+  ## Examples
+
+      iex> Backpex.LiveResource.return_to_param(%{"return_to" => "/admin/posts?page=2"})
+      "/admin/posts?page=2"
+
+      iex> Backpex.LiveResource.return_to_param(%{"return_to" => "https://evil.com"})
+      nil
+
+      iex> Backpex.LiveResource.return_to_param(%{"return_to" => "//evil.com"})
+      nil
+
+      iex> Backpex.LiveResource.return_to_param(%{})
+      nil
+  """
+  def return_to_param(params) do
+    case Map.get(params, "return_to") do
+      path when is_binary(path) -> if safe_return_to?(path), do: path
+      _other -> nil
+    end
+  end
+
+  defp safe_return_to?("//" <> _rest), do: false
+  defp safe_return_to?("/\\" <> _rest), do: false
+
+  defp safe_return_to?("/" <> _rest = path) do
+    uri = URI.parse(path)
+    is_nil(uri.scheme) and is_nil(uri.host)
+  end
+
+  defp safe_return_to?(_path), do: false
 end

--- a/lib/backpex/live_resource.ex
+++ b/lib/backpex/live_resource.ex
@@ -970,9 +970,9 @@ defmodule Backpex.LiveResource do
   destination, e.g. to send the user back to the page they came from.
 
   Only same-origin, absolute paths are accepted. Any value carrying a scheme or
-  host (`https://example.com`, `//example.com`, `/\\example.com`) is rejected to
-  prevent open redirects, in which case `nil` is returned and callers should
-  fall back to their default destination.
+  host (`https://example.com`, `//example.com`, `/\\example.com`), or containing
+  control characters, is rejected to prevent open redirects, in which case `nil`
+  is returned and callers should fall back to their default destination.
 
   ## Examples
 
@@ -1003,7 +1003,7 @@ defmodule Backpex.LiveResource do
 
   defp safe_return_to?("/" <> _rest = path) do
     uri = URI.parse(path)
-    is_nil(uri.scheme) and is_nil(uri.host)
+    is_nil(uri.scheme) and is_nil(uri.host) and not String.match?(path, ~r/[[:cntrl:]]/)
   end
 
   defp safe_return_to?(_path), do: false

--- a/lib/backpex/live_resource/form.ex
+++ b/lib/backpex/live_resource/form.ex
@@ -69,7 +69,7 @@ defmodule Backpex.LiveResource.Form do
   end
 
   defp assign_return_to(socket, params) do
-    case Map.get(params, "return_to") do
+    case LiveResource.return_to_param(params) do
       nil -> socket
       return_to -> assign(socket, :return_to, return_to)
     end

--- a/lib/backpex/live_resource/show.ex
+++ b/lib/backpex/live_resource/show.ex
@@ -65,7 +65,7 @@ defmodule Backpex.LiveResource.Show do
 
     socket
     |> assign(:item, item)
-    |> assign(:return_to, Router.get_path(socket, live_resource, params, :show, item))
+    |> assign(:return_to, return_to(socket, Router.get_path(socket, live_resource, params, :show, item)))
   end
 
   defp assign_item_actions(socket) do
@@ -92,7 +92,7 @@ defmodule Backpex.LiveResource.Show do
     socket
     |> assign(:selected_items, [item])
     |> Backpex.ItemAction.assign_action_changeset(action)
-    |> assign(:return_to, index_path)
+    |> assign(:return_to, return_to(socket, index_path))
     |> assign(:action_to_confirm, Map.put(action, :key, key))
     |> noreply()
   end
@@ -104,9 +104,16 @@ defmodule Backpex.LiveResource.Show do
     Backpex.ItemAction.handle_item_action(socket, action, key, [item], fn socket ->
       socket
       |> assign(action_to_confirm: nil)
-      |> maybe_navigate(index_path)
+      |> maybe_navigate(return_to(socket, index_path))
       |> noreply()
     end)
+  end
+
+  # Honors a `?return_to=` query param (validated against open redirects) so a
+  # link into the show view can override where item actions navigate afterwards.
+  # Falls back to the given default path when the param is absent or unsafe.
+  defp return_to(socket, default) do
+    Backpex.LiveResource.return_to_param(socket.assigns.params) || default
   end
 
   defp maybe_navigate(%{redirected: nil} = socket, path) do

--- a/test/backpex/live_resource_test.exs
+++ b/test/backpex/live_resource_test.exs
@@ -1,0 +1,41 @@
+defmodule Backpex.LiveResourceTest do
+  use ExUnit.Case, async: true
+
+  alias Backpex.LiveResource
+
+  describe "return_to_param/1" do
+    test "returns a same-origin absolute path" do
+      assert LiveResource.return_to_param(%{"return_to" => "/admin/posts"}) == "/admin/posts"
+    end
+
+    test "keeps a query string on the path" do
+      assert LiveResource.return_to_param(%{"return_to" => "/admin/posts?page=2"}) == "/admin/posts?page=2"
+    end
+
+    test "rejects a value with a scheme" do
+      assert LiveResource.return_to_param(%{"return_to" => "https://evil.com"}) == nil
+    end
+
+    test "rejects a protocol-relative value" do
+      assert LiveResource.return_to_param(%{"return_to" => "//evil.com"}) == nil
+    end
+
+    test "rejects a backslash-prefixed value" do
+      # A literal backslash (single-level escaping here); browsers may normalize it to "//".
+      assert LiveResource.return_to_param(%{"return_to" => "/\\evil.com"}) == nil
+    end
+
+    test "rejects a value containing control characters" do
+      assert LiveResource.return_to_param(%{"return_to" => "/foo\evil.com"}) == nil
+      assert LiveResource.return_to_param(%{"return_to" => "/foo\nbar"}) == nil
+    end
+
+    test "returns nil when the param is missing" do
+      assert LiveResource.return_to_param(%{}) == nil
+    end
+
+    test "returns nil when the param is not a string" do
+      assert LiveResource.return_to_param(%{"return_to" => ["/admin"]}) == nil
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

The form view (`:new` / `:edit`) already honors a `?return_to=` query parameter to
override where Backpex navigates after a save or cancel. The **show view** did not:
item actions triggered from a show page always navigated back to the index, with no
way for the linking page to control the destination.

This makes it awkward to link *into* a resource and send the user back where they came
from once they've acted on an item — e.g. a notification that links to a record and
should return the user to the notification list after they approve/reject it. Without
this, downstream apps have to reach for `on_mount` hooks that intercept the
`item-action` event and re-assign `:return_to`.

## Changes

- Add `Backpex.LiveResource.return_to_param/1`, which reads the `return_to` param and
  validates it, returning `nil` when it is absent or unsafe so callers fall back to
  their default destination.
- Honor the validated `?return_to=` param in the **show view** for both confirm-modal
  and direct item actions.
- Route the **form view**'s existing `return_to` param through the same helper.
- Document the parameter in the navigation guide.

## Security

The new helper only accepts same-origin, absolute paths. Any value carrying a scheme
or host is rejected to prevent open redirects, including:

- `https://evil.com` (scheme + host)
- `//evil.com` (protocol-relative)
- `/\evil.com` (backslash-prefixed)

Paths with query strings (e.g. `/admin/posts?page=2`) are still accepted. As a
side effect this also hardens the form view's `return_to`, which was previously
passed through unvalidated.

## Testing

- Doctests for `return_to_param/1` covering valid, external, protocol-relative and
  missing values.
- Demo LiveView tests for the show-view item action: honoring a valid `?return_to`,
  and ignoring external / protocol-relative values (falling back to the index).
- `mix compile --warnings-as-errors`, full test suite, credo and format all pass.
