### PR TITLE
Remove unused jason dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,6 @@ defmodule Backpex.MixProject do
       # core
       {:nimble_options, "~> 1.1"},
       {:gettext, ">= 0.26.0"},
-      {:jason, "~> 1.2"},
 
       # phoenix
       {:phoenix, ">= 1.7.6 and < 1.9.0"},


### PR DESCRIPTION
## What

`{:jason, "~> 1.2"}` is declared in `mix.exs` but never used.

## Evidence

It appears nowhere outside its own declaration:

```
$ grep -rn "Jason\|jason" lib/ priv/templates/ mix.exs
mix.exs:54:      {:jason, "~> 1.2"},
```

Unlike `number` (#2113), there is no commit that removed a call site — `git log -S"Jason." -- lib/` is empty across all branches. It appears to have been unused for as long as it has been declared.

Backpex does not serialize anything itself; host applications configure their own JSON library for Phoenix and Ecto.

## Impact

`mix.lock` is unchanged: `jason` remains as a transitive dependency of `credo`, `esbuild`, `igniter` and `mix_audit`. This only removes the direct declaration, so nothing is dropped from the resolution — the point is that Backpex no longer constrains a package it does not use.

## Verification

`mix lint` passes end to end (`compile --warning-as-errors`, `deps.unlock --unused`, `format`, `credo`, 100 doctests + 174 tests, 0 failures), and `mix docs --warnings-as-errors` builds.

## Context

Found by a dependency check I am preparing separately, which reports dependencies that are declared but never referenced by the compiled code — the blind spot that let `number` sit unused for two years until it blocked `decimal` 3.x (#2113). `mix deps.unlock --check-unused` cannot see this class of problem, since it only compares `mix.lock` against `mix.exs`.