### PR TITLE
Add id to per page select form

### DIFF
--- a/lib/backpex/html/resource.ex
+++ b/lib/backpex/html/resource.ex
@@ -867,7 +867,13 @@ defmodule Backpex.HTML.Resource do
       |> assign(:selected, assigns.query_options.per_page)
 
     ~H"""
-    <.form for={@form} class={@class} phx-change="select-page-size" phx-submit="select-page-size">
+    <.form
+      for={@form}
+      id="select-per-page-form"
+      class={@class}
+      phx-change="select-page-size"
+      phx-submit="select-page-size"
+    >
       <select name={@form[:value].name} class="select select-sm" aria-label={Backpex.__("Items per page", @live_resource)}>
         <button>
           <selectedcontent></selectedcontent>


### PR DESCRIPTION
## Description

The per page `<.form>` rendered by `Backpex.HTML.Resource.select_per_page/1` had no `id`, which triggers a LiveView test warning:

> Detected a form with phx-change but missing id

Without an `id`, LiveView cannot perform form recovery after a crash or reconnect.

This adds a static `id="select-per-page-form"`. The component is rendered once per index view (`resource_index_main.html.heex`), so a static id stays unique.

## Testing

- `mix format` / `mix credo` clean
- `MIX_ENV=test mix lint` — 174 tests, 0 failures
- Verified end-to-end in a downstream app: patching the dep and recompiling removes the warning from the test output.