### PR TITLE
Add id to index form

### DIFF
--- a/lib/backpex/fields/belongs_to.ex
+++ b/lib/backpex/fields/belongs_to.ex
@@ -171,7 +171,14 @@ defmodule Backpex.Fields.BelongsTo do
 
     ~H"""
     <div>
-      <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
+      <.form
+        for={@form}
+        id={"index-form-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
+        class="relative"
+        phx-change="update-field"
+        phx-submit="update-field"
+        phx-target={@myself}
+      >
         <BackpexForm.input
           id={"index-form-input-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
           type="select"

--- a/lib/backpex/fields/boolean.ex
+++ b/lib/backpex/fields/boolean.ex
@@ -65,7 +65,14 @@ defmodule Backpex.Fields.Boolean do
 
     ~H"""
     <div>
-      <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
+      <.form
+        for={@form}
+        id={"index-form-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
+        class="relative"
+        phx-change="update-field"
+        phx-submit="update-field"
+        phx-target={@myself}
+      >
         <BackpexForm.input
           id={"index-form-input-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
           type="toggle"

--- a/lib/backpex/fields/date.ex
+++ b/lib/backpex/fields/date.ex
@@ -133,7 +133,13 @@ defmodule Backpex.Fields.Date do
 
     ~H"""
     <div>
-      <.form for={@form} phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
+      <.form
+        for={@form}
+        id={"index-form-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
+        phx-change="update-field"
+        phx-submit="update-field"
+        phx-target={@myself}
+      >
         <BackpexForm.input
           id={"index-form-input-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
           type="date"

--- a/lib/backpex/fields/date_time.ex
+++ b/lib/backpex/fields/date_time.ex
@@ -133,7 +133,13 @@ defmodule Backpex.Fields.DateTime do
 
     ~H"""
     <div>
-      <.form for={@form} phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
+      <.form
+        for={@form}
+        id={"index-form-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
+        phx-change="update-field"
+        phx-submit="update-field"
+        phx-target={@myself}
+      >
         <BackpexForm.input
           id={"index-form-input-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
           type="datetime-local"

--- a/lib/backpex/fields/email.ex
+++ b/lib/backpex/fields/email.ex
@@ -75,7 +75,14 @@ defmodule Backpex.Fields.Email do
 
     ~H"""
     <div>
-      <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
+      <.form
+        for={@form}
+        id={"index-form-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
+        class="relative"
+        phx-change="update-field"
+        phx-submit="update-field"
+        phx-target={@myself}
+      >
         <BackpexForm.input
           id={"index-form-input-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
           type="email"

--- a/lib/backpex/fields/number.ex
+++ b/lib/backpex/fields/number.ex
@@ -75,7 +75,14 @@ defmodule Backpex.Fields.Number do
 
     ~H"""
     <div>
-      <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
+      <.form
+        for={@form}
+        id={"index-form-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
+        class="relative"
+        phx-change="update-field"
+        phx-submit="update-field"
+        phx-target={@myself}
+      >
         <BackpexForm.input
           id={"index-form-input-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
           type="number"

--- a/lib/backpex/fields/select.ex
+++ b/lib/backpex/fields/select.ex
@@ -103,7 +103,14 @@ defmodule Backpex.Fields.Select do
 
     ~H"""
     <div>
-      <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
+      <.form
+        for={@form}
+        id={"index-form-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
+        class="relative"
+        phx-change="update-field"
+        phx-submit="update-field"
+        phx-target={@myself}
+      >
         <BackpexForm.input
           id={"index-form-input-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
           type="select"

--- a/lib/backpex/fields/text.ex
+++ b/lib/backpex/fields/text.ex
@@ -75,7 +75,14 @@ defmodule Backpex.Fields.Text do
 
     ~H"""
     <div>
-      <.form for={@form} class="relative" phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
+      <.form
+        for={@form}
+        id={"index-form-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
+        class="relative"
+        phx-change="update-field"
+        phx-submit="update-field"
+        phx-target={@myself}
+      >
         <BackpexForm.input
           id={"index-form-input-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
           type="text"

--- a/lib/backpex/fields/time.ex
+++ b/lib/backpex/fields/time.ex
@@ -106,7 +106,13 @@ defmodule Backpex.Fields.Time do
 
     ~H"""
     <div>
-      <.form for={@form} phx-change="update-field" phx-submit="update-field" phx-target={@myself}>
+      <.form
+        for={@form}
+        id={"index-form-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
+        phx-change="update-field"
+        phx-submit="update-field"
+        phx-target={@myself}
+      >
         <BackpexForm.input
           id={"index-form-input-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
           type="time"

--- a/lib/backpex/html/resource.ex
+++ b/lib/backpex/html/resource.ex
@@ -1151,7 +1151,7 @@ defmodule Backpex.HTML.Resource do
 
   ## Examples
 
-      <.form :let={f} for={@form} phx-change="validate" phx-submit="submit">
+      <.form :let={f} for={@form} id="edit-form" phx-change="validate" phx-submit="submit">
         <.edit_card>
           <:panel label="Names">
             <.input field={f[:first_name]} type="text" />


### PR DESCRIPTION
Index forms rendered by the built-in fields carry `phx-change` but no `id`. Without an id LiveView cannot perform form recovery after a crash or disconnect, and `Phoenix.LiveViewTest` reports a `missing_form_id` warning for every render.

This follows #2122 (per-page select form) and #2089 (filter form), which fixed the same class of warning elsewhere.

## Changes

Adds an `id` to the index form in the nine fields that render one: `belongs_to`, `boolean`, `date`, `date_time`, `email`, `number`, `select`, `text`, `time`.

The id reuses the expression already used for the index form input directly below it:

```elixir
id={"index-form-#{@name}-#{LiveResource.primary_value(@item, @live_resource)}"}
```

That keeps it unique per field and per item, and correct for resources with a custom or composite primary key.

Also adds an `id` to the `<.form>` in the `edit_card/1` doc example, so the documented pattern doesn't demonstrate the thing that triggers the warning.

## Verification

- `mix lint` — compile with `--warning-as-errors`, format, and credo all clean
- `MIX_ENV=test mix test` — 100 doctests, 174 tests, 0 failures