### PR TITLE
Fix bad version suggestions in docs/skills

### DIFF
--- a/guides/ai_development/ai-development.md
+++ b/guides/ai_development/ai-development.md
@@ -62,7 +62,7 @@ Example: "Create an export action that lets users download posts as CSV"
 
 The `upgrade` skill assists with Backpex version upgrades. It reads the relevant upgrade guides, identifies breaking changes, and applies migrations systematically.
 
-Example: "Upgrade Backpex from 0.16 to 0.18"
+Example: "Upgrade Backpex from 0.16 to 0.19"
 
 ## Invoking Skills
 

--- a/guides/get_started/installation.md
+++ b/guides/get_started/installation.md
@@ -38,7 +38,7 @@ In your `mix.exs`:
 defp deps do
   [
     ...
-    {:backpex, "~> 0.13.0"}
+    {:backpex, "~> 0.19"}
   ]
 end
 ```

--- a/skills/upgrade/SKILL.md
+++ b/skills/upgrade/SKILL.md
@@ -17,7 +17,7 @@ You are an expert at upgrading Backpex versions. When the user wants to upgrade,
 Check `mix.exs` for the Backpex dependency:
 
 ```elixir
-{:backpex, "~> 0.17.0"}
+{:backpex, "~> 0.19.0"}
 ```
 
 ## Upgrade Guides Location
@@ -45,11 +45,11 @@ All upgrade guides are at `guides/upgrading/` in the Backpex repository (also av
 
 ## Upgrade Process
 
-1. **Read ALL upgrade guides** between current and target version. For example, upgrading from 0.15 to 0.18 requires reading v0.16, v0.17, and v0.18 guides.
+1. **Read ALL upgrade guides** between current and target version. For example, upgrading from 0.15 to 0.19 requires reading v0.16, v0.17, v0.18, and v0.19 guides.
 
 2. **Bump the dependency** in `mix.exs`:
    ```elixir
-   {:backpex, "~> 0.18.0"}
+   {:backpex, "~> 0.19.0"}
    ```
 
 3. **Run `mix deps.get`** to fetch the new version.


### PR DESCRIPTION
Hello,

Thanks for Backpex! This small patch updates bad version suggestions across documentation and skill files. I stumbled on this problem when setting up Backpex by following the docs and having my Phoenix 1.8 project breaking dependency resolution. The docs suggested 0.13 as the version to be used during setup while 0.19 is already available.

I used AI to search for other outdated entries in regard to version suggestions, and ended up finding small ones, which I added to this PR.