### PR TITLE
Add 3 day release cooldown for Hex dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,8 @@
     "github>pehbehbeh/renovate-config//customManagers/hexTailwind",
     ":reviewer(Flo0807)",
     "helpers:pinGitHubActionDigestsToSemver",
-    "security:minimumReleaseAgeNpm"
+    "security:minimumReleaseAgeNpm",
+    "local>naymspace/backpex//.github/renovate/minimumReleaseAgeHex"
   ],
   "additionalBranchPrefix": "{{packageFileDir}}-",
   "pinDigests": false,

--- a/.github/renovate/minimumReleaseAgeHex.json
+++ b/.github/renovate/minimumReleaseAgeHex.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Set a minimum release age of 3 days for Hex packages, to give time for a new release to be flagged as malicious.",
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "hex"
+      ],
+      "minimumReleaseAge": "3 days",
+      "internalChecksFilter": "strict"
+    },
+    {
+      "matchDatasources": [
+        "hex"
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
+      "matchDatasources": [
+        "hex"
+      ],
+      "matchUpdateTypes": [
+        "replacement"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
+      "matchDatasources": [
+        "hex"
+      ],
+      "matchUpdateTypes": [
+        "pin"
+      ],
+      "minimumReleaseAge": null
+    }
+  ]
+}

--- a/demo/mix.exs
+++ b/demo/mix.exs
@@ -13,6 +13,7 @@ defmodule Demo.MixProject do
       deps: deps(),
       aliases: aliases(),
       gettext: gettext(),
+      hex: [cooldown: "3d"],
       listeners: [Phoenix.CodeReloader]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -20,6 +20,7 @@ defmodule Backpex.MixProject do
       gettext: gettext(),
 
       # Hex.pm
+      hex: [cooldown: "3d"],
       package: package(),
       description: "Highly customizable administration panel for Phoenix LiveView applications.",
 


### PR DESCRIPTION
## Motivation

Give newly published Hex releases time to be flagged as malicious before they can be pulled into the project — the same idea as the `security:minimumReleaseAgeNpm` preset we already extend for npm.

## Changes

**Hex cooldown (`mix.exs`, `demo/mix.exs`)**

Set `hex: [cooldown: "3d"]` in both projects. Hex then holds back package versions published less than three days ago during dependency resolution. Versions already in `mix.lock` are exempt, so `mix deps.get` against an intact lockfile is unaffected.

Note: the cooldown option requires **Hex >= 2.5.0**. Older Hex versions ignore the key, so this is a no-op for them rather than an error.

**Renovate preset (`.github/renovate/minimumReleaseAgeHex.json`)**

New local preset applying `minimumReleaseAge: "3 days"` with `internalChecksFilter: "strict"` to the `hex` datasource, extended from `.github/renovate.json`. Lock file maintenance, replacement and pin updates are exempt from the cooldown.

## Checks

- `mix format --check-formatted mix.exs` passes
- Both `mix.exs` files parse; both JSON files are valid

The preset is resolved from the default branch, so Renovate will only pick it up after this PR is merged.