### PR TITLE
Add anchor_text option to URL field

### DIFF
--- a/demo/lib/demo_web/live/product_live.ex
+++ b/demo/lib/demo_web/live/product_live.ex
@@ -72,7 +72,12 @@ defmodule DemoWeb.ProductLive do
       manufacturer: %{
         module: Backpex.Fields.URL,
         label: "Manufacturer URL",
-        orderable: false
+        orderable: false,
+        anchor_text: fn assigns ->
+          host = URI.parse(assigns.value).host
+          name = String.replace(host, ~r/\.(com|org|net|io)$/, "")
+          "Visit #{name}"
+        end
       },
       quantity: %{
         module: Backpex.Fields.Number,

--- a/demo/test/demo_web/live/product/index_live_test.exs
+++ b/demo/test/demo_web/live/product/index_live_test.exs
@@ -54,5 +54,19 @@ defmodule DemoWeb.Live.Product.IndexLiveTest do
       test_show_action_redirect(conn, ~p"/admin/products", products)
       test_edit_action_redirect(conn, ~p"/admin/products", products)
     end
+
+    test "manufacturer URL renders anchor_text instead of raw URL", %{conn: conn} do
+      insert(:product, %{
+        name: "Widget",
+        quantity: 1,
+        manufacturer: "https://example.com",
+        price: Money.new(1000, :USD)
+      })
+
+      conn
+      |> visit(~p"/admin/products")
+      |> assert_has("a[href='https://example.com']", text: "Visit example", exact: true)
+      |> refute_has("a", text: "https://example.com", exact: true)
+    end
   end
 end

--- a/lib/backpex/fields/url.ex
+++ b/lib/backpex/fields/url.ex
@@ -18,6 +18,11 @@ defmodule Backpex.Fields.URL do
         "List of allowed schemes for the link (e.g. https). Values with disallowed scheme are displayed as raw text.",
       type: {:list, :string},
       default: ~w(https http tel mailto)
+    ],
+    anchor_text: [
+      doc:
+        "Anchor text to be displayed for the link on index and show views. Defaults to the URL. Can be a string or a function that receives the assigns.",
+      type: {:or, [:string, {:fun, 1}]}
     ]
   ]
 
@@ -34,12 +39,15 @@ defmodule Backpex.Fields.URL do
 
   @impl Backpex.Field
   def render_value(assigns) do
-    assigns = assign(assigns, :valid?, valid_url?(assigns.value, assigns.field_options))
+    assigns =
+      assigns
+      |> assign(:valid?, valid_url?(assigns.value, assigns.field_options))
+      |> assign(:anchor_text, anchor_text(assigns.value, assigns.field_options, assigns))
 
     ~H"""
     <p class={@live_action in [:index, :resource_action] && "truncate"}>
       <.link :if={@valid?} href={@value} class="text-blue-600 underline">
-        {@value}
+        {@anchor_text}
       </.link>
       <span :if={!@valid?}>{@value}</span>
     </p>
@@ -80,4 +88,8 @@ defmodule Backpex.Fields.URL do
   end
 
   defp valid_url?(_value, _field_options), do: false
+
+  defp anchor_text(_value, %{anchor_text: text}, _assigns) when is_binary(text), do: text
+  defp anchor_text(_value, %{anchor_text: fun}, assigns) when is_function(fun, 1), do: fun.(assigns)
+  defp anchor_text(value, _field_options, _assigns), do: value
 end


### PR DESCRIPTION
## Summary

- Add `anchor_text` option to `Backpex.Fields.URL` config schema
- Accepts a string or a 1-arity function that receives the assigns
- Defaults to the URL when unset (backward compatible)
- Update demo to showcase the feature on Product manufacturer field

Closes #321

## Behavior

| Config | Rendered link text |
|---|---|
| (no option) | URL (unchanged) |
| `anchor_text: "Visit site"` | "Visit site" |
| `anchor_text: fn assigns -> ... end` | function return value |

The `href` always remains the original URL. Invalid/disallowed URLs still render as raw text (unchanged).

## Test plan

- [x] `mix format` clean
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo` — no issues
- [x] `mix test` — 274 passed (library)
- [x] Demo test verifies anchor text renders and raw URL does not
- [x] Manual browser check at http://localhost:4000/admin/products