### PR TITLE
Fix HasMany badge accessibility label

### DIFF
--- a/lib/backpex/fields/has_many.ex
+++ b/lib/backpex/fields/has_many.ex
@@ -314,8 +314,10 @@ defmodule Backpex.Fields.HasMany do
       <label
         class="flex cursor-pointer items-center pr-2"
         for={"has-many-#{@name}-checkbox-value-#{@value}"}
-        aria-label={Backpex.__({"Unselect %{label}", %{label: @label}}, @live_resource)}
       >
+        <span class="sr-only">
+          {Backpex.__({"Unselect %{label}", %{label: @label}}, @live_resource)}
+        </span>
         <Backpex.HTML.CoreComponents.icon name="hero-x-mark" class="size-4 scale-105 hover:scale-110" />
       </label>
     </div>


### PR DESCRIPTION
## Summary

- replace the prohibited `aria-label` on the HasMany badge label
- preserve the translated accessible name as screen-reader-only label content

## Context

Fixes the `aria-prohibited-attr` failure exposed by the `a11y_audit` 0.5.0 upgrade.