### PR TITLE
Remove prohibited aria-label from HasMany badge

### DIFF
--- a/lib/backpex/fields/has_many.ex
+++ b/lib/backpex/fields/has_many.ex
@@ -304,11 +304,6 @@ defmodule Backpex.Fields.HasMany do
     ~H"""
     <div class="badge badge-sm badge-soft badge-primary pointer-events-auto pr-0">
       <span>{@label}</span>
-      <%!--
-      The label is a pointer-only shortcut for the checkbox it points to. Screen reader users
-      unselect the option via that checkbox, so the label is hidden to keep it out of the
-      accessible name of the surrounding dropdown trigger.
-      --%>
       <label
         class="flex cursor-pointer items-center pr-2"
         for={"has-many-#{@name}-checkbox-value-#{@value}"}

--- a/lib/backpex/fields/has_many.ex
+++ b/lib/backpex/fields/has_many.ex
@@ -156,13 +156,7 @@ defmodule Backpex.Fields.HasMany do
           >
             <div class="flex h-full w-full flex-wrap items-center gap-1 px-2">
               <p :if={@selected == []} class="p-0.5 text-sm">{@prompt}</p>
-              <.badge
-                :for={{label, value} <- @selected}
-                live_resource={@live_resource}
-                label={label}
-                value={value}
-                name={@name}
-              />
+              <.badge :for={{label, value} <- @selected} label={label} value={value} name={@name} />
             </div>
           </:trigger>
           <:menu class="w-full overflow-y-auto">
@@ -302,7 +296,6 @@ defmodule Backpex.Fields.HasMany do
     """
   end
 
-  attr :live_resource, :atom, required: true
   attr :name, :string, required: true
   attr :label, :string, required: true
   attr :value, :string, required: true
@@ -311,10 +304,15 @@ defmodule Backpex.Fields.HasMany do
     ~H"""
     <div class="badge badge-sm badge-soft badge-primary pointer-events-auto pr-0">
       <span>{@label}</span>
+      <%!--
+      The label is a pointer-only shortcut for the checkbox it points to. Screen reader users
+      unselect the option via that checkbox, so the label is hidden to keep it out of the
+      accessible name of the surrounding dropdown trigger.
+      --%>
       <label
         class="flex cursor-pointer items-center pr-2"
         for={"has-many-#{@name}-checkbox-value-#{@value}"}
-        aria-label={Backpex.__({"Unselect %{label}", %{label: @label}}, @live_resource)}
+        aria-hidden="true"
       >
         <Backpex.HTML.CoreComponents.icon name="hero-x-mark" class="size-4 scale-105 hover:scale-110" />
       </label>


### PR DESCRIPTION
## Problem

CI on [#2206 (`Update dependency a11y_audit to ~> 0.5.0`)](https://github.com/naymspace/backpex/pull/2206) fails with one accessibility violation:

```
1) test posts edit a11y (DemoWeb.Browser.PostBrowserTest)
   Expected page to have no accessibility violations, but got 1 violation.

   serious  Elements must only use permitted ARIA attributes
   https://dequeuniversity.com/rules/axe/4.13/aria-prohibited-attr

   There are 2 nodes with this violation:
   1. <label class="flex cursor-pointer items-center pr-2" for="has-many-tags-checkbox-value-…
        - aria-label attribute cannot be used on a label with no valid role attribute.
```

`a11y_audit` 0.5.0 ships a newer axe-core, whose `aria-prohibited-attr` rule now flags this. The `<label>` element has no corresponding ARIA role, so `aria-label` is not allowed on it — and is ignored by assistive technology anyway.

## Fix

The offending element is the "x" of a selected badge in `Backpex.Fields.HasMany`. It is a `<label for=…>` pointing at the option's checkbox, so clicking it unselects the option.

That label is a **pointer-only** shortcut: labels are not focusable, so keyboard and screen reader users never reached it. They unselect an option via the checkbox in the dropdown menu instead. So the label is now hidden from assistive technology with `aria-hidden="true"` rather than given a name it cannot expose.

This has a second benefit: the badges live inside the dropdown trigger, which has `role="button"` and therefore derives its accessible name from its contents. Previously each badge contributed a duplicated "Unselect <label>" to that name; now the trigger announces just the selected labels.

Alternatives considered:

- **`sr-only` text inside the label** — the label is associated with the checkbox via `for`, so the text would be appended to the checkbox's accessible name ("Tag Unselect Tag") *and* to the trigger's.
- **`role="button"` on the label** (as `multi_select_badge` in `Backpex.HTML.Form` does on a `<div>`) — would permit `aria-label`, but creates a button that is not keyboard focusable, and risks tripping `aria-allowed-role`.

The `"Unselect %{label}"` translation is still used by `Backpex.HTML.Form.multi_select_badge`, where it sits on a `<div role="button">` and is permitted, so no gettext changes are needed.

## Verification

Run locally against `a11y_audit` 0.5.0 (the version from #2206):

- Before: `Result: 3/4 passed` — `posts edit a11y` fails with the violation above.
- After: `Result: 41 passed, 325 excluded` (full `--only playwright` suite; previously 40/41).

Also green: `mix test` (158 doctests, 447 tests, 0 failures), `mix format`, `mix credo`.

Once this lands, #2206 should go green after a rebase.
